### PR TITLE
Add a color parameter to IconDrawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [ADD] Add a method to manually set the default font
 * [REFACTOR] Refactor method names and JSON keys
 * [ADD] Add keypad icons
+* [ADD] Add a color parameter to IconDrawing
 
 ## 1.1.0
 * [ADD] Add new icons

--- a/README.md
+++ b/README.md
@@ -140,3 +140,15 @@ If you encounter issues with connecting to your GYW device, here are a few thing
 5. If the device is not listed, switch it off and then back on, and start a scan again.
 6. Restart your app.
 7. If you continue to have issues, please contact our support team for further assistance at [support@getyourway.be](mailto:support@getyourway.be)
+
+### What is the format of the color parameter for the IconDrawing ?
+
+The color parameter of an IconDrawing must be 8 characters long and represents the color in the **ORGB format**.
+
+The ORGB format is a hexadecimal color format used in Flutter that represents the color components of an opaque or transparent color as four two-digit hexadecimal numbers, in the order of **opacity** (**alpha**), **red**, **green**, and **blue**. It is an 8-digit color code that ranges from 00000000 (fully transparent black) to FFFFFFFF (fully opaque white).
+
+In Flutter, you can convert a Material Color to this format with this piece of code:
+
+```dart
+color.value.toRadixString(16).padLeft(8, "0");
+```

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -212,7 +212,7 @@ class IconDrawing extends GYWDrawing {
     return <GYWBtCommand>[
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
-        const Utf8Encoder().convert("${icon.filename}.png"),
+        const Utf8Encoder().convert("${icon.filename}.bin"),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -64,7 +64,6 @@ class TextDrawing extends GYWDrawing {
     // Bytes generation for the control data (command code + params)
     final controlBytes = BytesBuilder();
 
-
     controlBytes.add(int8Bytes(GYWControlCode.displayText.value));
     controlBytes.add(int32Bytes(left));
     controlBytes.add(int32Bytes(top));
@@ -188,10 +187,14 @@ class IconDrawing extends GYWDrawing {
   /// The displayed icon
   final GYWIcon icon;
 
+  /// Hexadecimal code of the icon fill color
+  final String? color;
+
   const IconDrawing(
     this.icon, {
     super.top,
     super.left,
+    this.color,
   });
 
   @override
@@ -200,6 +203,11 @@ class IconDrawing extends GYWDrawing {
     controlBytes.add(int8Bytes(GYWControlCode.displayImage.value));
     controlBytes.add(int32Bytes(left));
     controlBytes.add(int32Bytes(top));
+
+    if (color != null) {
+      // Add color value
+      controlBytes.add(utf8.encode(color!));
+    }
 
     return <GYWBtCommand>[
       GYWBtCommand(
@@ -221,7 +229,10 @@ class IconDrawing extends GYWDrawing {
   @override
   bool operator ==(Object other) {
     if (other is IconDrawing) {
-      return icon == other.icon && left == other.left && top == other.top;
+      return icon == other.icon &&
+          color == other.color &&
+          left == other.left &&
+          top == other.top;
     } else {
       return false;
     }
@@ -229,7 +240,10 @@ class IconDrawing extends GYWDrawing {
 
   @override
   int get hashCode =>
-      29 * icon.hashCode + 57 * left.hashCode + 17 * top.hashCode;
+      29 * icon.hashCode +
+      57 * left.hashCode +
+      17 * top.hashCode +
+      23 * color.hashCode;
 
   /// Deserialize an [IconDrawing] from JSON data
   factory IconDrawing.fromJson(Map<String, dynamic> data) {
@@ -242,6 +256,7 @@ class IconDrawing extends GYWDrawing {
       ),
       left: data["left"] as int,
       top: data["top"] as int,
+      color: data["color"] as String?,
     );
   }
 
@@ -254,6 +269,7 @@ class IconDrawing extends GYWDrawing {
       // Deprecated: "icon" key will be deprecated in future versions
       "icon": icon.name,
       "data": icon.filename,
+      "color": color,
     };
   }
 }

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -71,6 +71,19 @@ void main() {
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
+    test('Icon with color', () {
+      const GYWIcon icon = GYWIcon.left;
+
+      const GYWDrawing drawing = IconDrawing(
+        icon,
+        left: 120,
+        top: 220,
+        color: "ff00ff00",
+      );
+
+      expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
+    });
+
     test('Unsupported type', () {
       final json = {
         "type": "unsupported",


### PR DESCRIPTION
You can now specify the color in which the icon should be drawn. If it is not specified or if the specified color is badly formatted, the icon will be drawn in black.