### PR TITLE
[ADD] Add size and color parameter to TextDrawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.2 [In development]
+* [ADD] Add color and size to texts elements
+
 ## 1.1.1
 * [IMP] Integrate font in text control instruction
 * [ADD] Add a method to manually set the default font

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.1.2 [In development]
-* [ADD] Add color and size to texts elements
+* [ADD] Add size and color parameters to TextDrawing
 
 ## 1.1.1
 * [IMP] Integrate font in text control instruction

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ If you encounter issues with connecting to your GYW device, here are a few thing
 6. Restart your app.
 7. If you continue to have issues, please contact our support team for further assistance at [support@getyourway.be](mailto:support@getyourway.be)
 
-### What is the format of the color parameter for the IconDrawing ?
+### What is the format of the color parameter of the `TexDrawing` and `IconDrawing`  ?
 
-The color parameter of an IconDrawing must be 8 characters long and represents the color in the **ORGB format**.
+The color parameter of a drawing must be 8 characters long and represents the color in the **ORGB format**.
 
-The ORGB format is a hexadecimal color format used in Flutter that represents the color components of an opaque or transparent color as four two-digit hexadecimal numbers, in the order of **opacity** (**alpha**), **red**, **green**, and **blue**. It is an 8-digit color code that ranges from 00000000 (fully transparent black) to FFFFFFFF (fully opaque white).
+The ORGB format is a hexadecimal color format used in Flutter that represents the color components of an opaque or transparent color as four two-digit hexadecimal numbers, in the order of **opacity** (**alpha**), **red**, **green**, and **blue**. It is an 8-digit color code that ranges from `00000000` (fully transparent black) to `FFFFFFFF` (fully opaque white).
 
 In Flutter, you can convert a Material Color to this format with this piece of code:
 
@@ -184,3 +184,7 @@ The font used on the aRdent glasses is **RobotoMono**.
 ![Example of RobotoMono text](static/img/RobotoMono.png)
 
 You can download it from [Google fonts](https://fonts.google.com/specimen/Roboto+Mono).
+
+### Why does the color and the size parameter of a `TextDrawing` has no impact ?
+
+Color and size of the TextDrawing are two features that will be enabled in the future. For now, those are only there to help developers to prepare their developments with this feature.

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -52,9 +52,17 @@ class TextDrawing extends GYWDrawing {
   /// If no font is given, it uses the most recent one
   final GYWFont? font;
 
+  /// size of the text (max 48 pt)
+  final int? size;
+
+  /// color of the text (in 8-characters ORGB format)
+  final String? color;
+
   const TextDrawing({
     required this.text,
     this.font,
+    this.size,
+    this.color,
     super.left = 0,
     super.top = 0,
   });
@@ -96,7 +104,9 @@ class TextDrawing extends GYWDrawing {
       return text == other.text &&
           left == other.left &&
           top == other.top &&
-          font == other.font;
+          font == other.font &&
+          size == other.size &&
+          color == other.color;
     } else {
       return false;
     }
@@ -107,7 +117,9 @@ class TextDrawing extends GYWDrawing {
       37 * text.hashCode +
       23 * font.hashCode +
       51 * left.hashCode +
-      13 * top.hashCode;
+      13 * top.hashCode +
+      19 * size.hashCode +
+      41 * color.hashCode;
 
   /// Deserialize a [TextDrawing] from JSON data
   factory TextDrawing.fromJson(Map<String, dynamic> data) {
@@ -126,6 +138,8 @@ class TextDrawing extends GYWDrawing {
       // Deprecated: "text" key will be deprecated in future version
       text: data["data"] as String? ?? data["text"] as String,
       font: font,
+      size: data["size"] as int?,
+      color: data["color"] as String?,
     );
   }
 
@@ -139,6 +153,8 @@ class TextDrawing extends GYWDrawing {
       // Deprecated: "text" key will be deprecated in future version
       "text": text,
       if (font != null) "font": font!.index,
+      "size": size,
+      "color": color,
     };
   }
 }


### PR DESCRIPTION
In the future versions of the firmware, it will be possible to choose the color and the size of a text. To help developers to prepare this feature, the API has been completed with these two parameters. However, do not be surprised that it does not impact the color or the size of the element on the aRdent glasses.