### PR TITLE
Convert WhiteScreen into BlankScreen with a color parameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.2 [In development]
 * [ADD] Add size and color parameters to TextDrawing
+* [ADD] Convert WhiteScreen into BlankScreen with a color parameter 
 
 ## 1.1.1
 * [IMP] Integrate font in text control instruction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.2 [In development]
+* [ADD] Add color and size to texts elements
+
 ## 1.1.1
 * [IMP] Integrate font in text control instruction
 * [ADD] Add a method to manually set the default font

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.1.2 [In development]
-* [ADD] Add color and size to texts elements
+* [ADD] Add size and color parameters to TextDrawing
 
 ## 1.1.1
 * [IMP] Integrate font in text control instruction

--- a/README.md
+++ b/README.md
@@ -123,17 +123,19 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ### How to reset the screen of the aRdent glasses?
 
-`GYWDrawing` objects appear on the screen as a stack. Each new drawing will be printed over the previous one. Therefore, to reset the screen, you need to send a white screen that will override the whole screen.
+`GYWDrawing` objects appear on the screen as a stack. Each new drawing will be printed over the previous one. Therefore, to reset the screen, you need to send a blank screen that will override the whole screen.
 
-To achieve this, you can use a `WhiteScreen` drawing:
+To achieve this, you can use a `BlankScreen` drawing:
 
 ```dart
-device.sendDrawing(const WhiteScreen());
+device.sendDrawing(const Blankcreen());
 ```
 
-By sending this white screen drawing, it will replace all previous drawings and create a blank canvas for new content to be displayed.
+By sending this drawing, it will replace all previous drawings and create a blank canvas for new content to be displayed.
 
-Alternatively, if you only need to modify specific elements on the screen, such as toggling a checkbox or changing the color of an icon, you can use the `blank` icon and color it in white. Then, you can display additional elements on top of it. However, keep in mind that stacking too many elements without clearing the screen may consume memory resources, so it's recommended to periodically clear the screen using the `WhiteScreen` drawing when necessary.
+Alternatively, if you only need to modify specific elements on the screen, such as toggling a checkbox or changing the color of an icon, you can use the `blank` icon and color it in the same color as the background. Then, you can display additional elements on top of it. However, keep in mind that stacking too many elements without clearing the screen may consume memory resources, so it's recommended to periodically clear the screen using the `BlankScreen` drawing when necessary.
+
+Note that through this drawing, you can change the background color.
 
 ### How can I have bigger icons?
 
@@ -151,9 +153,9 @@ If you encounter issues with connecting to your GYW device, here are a few thing
 6. Restart your app.
 7. If you continue to have issues, please contact our support team for further assistance at [support@getyourway.be](mailto:support@getyourway.be)
 
-### What is the format of the color parameter of the `TexDrawing` and `IconDrawing`  ?
+### What is the format of the `color` parameter of the `GYWDrawing`  ?
 
-The color parameter of a drawing must be 8 characters long and represents the color in the **ORGB format**.
+The `color` parameter of a drawing must be 8 characters long and represents the color in the **ORGB format**.
 
 The ORGB format is a hexadecimal color format used in Flutter that represents the color components of an opaque or transparent color as four two-digit hexadecimal numbers, in the order of **opacity** (**alpha**), **red**, **green**, and **blue**. It is an 8-digit color code that ranges from `00000000` (fully transparent black) to `FFFFFFFF` (fully opaque white).
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ If you encounter issues with connecting to your GYW device, here are a few thing
 6. Restart your app.
 7. If you continue to have issues, please contact our support team for further assistance at [support@getyourway.be](mailto:support@getyourway.be)
 
-### What is the format of the color parameter for the IconDrawing ?
+### What is the format of the color parameter of the `TexDrawing` and `IconDrawing`  ?
 
-The color parameter of an IconDrawing must be 8 characters long and represents the color in the **ORGB format**.
+The color parameter of a drawing must be 8 characters long and represents the color in the **ORGB format**.
 
-The ORGB format is a hexadecimal color format used in Flutter that represents the color components of an opaque or transparent color as four two-digit hexadecimal numbers, in the order of **opacity** (**alpha**), **red**, **green**, and **blue**. It is an 8-digit color code that ranges from 00000000 (fully transparent black) to FFFFFFFF (fully opaque white).
+The ORGB format is a hexadecimal color format used in Flutter that represents the color components of an opaque or transparent color as four two-digit hexadecimal numbers, in the order of **opacity** (**alpha**), **red**, **green**, and **blue**. It is an 8-digit color code that ranges from `00000000` (fully transparent black) to `FFFFFFFF` (fully opaque white).
 
 In Flutter, you can convert a Material Color to this format with this piece of code:
 
@@ -184,3 +184,7 @@ The font used on the aRdent glasses is **RobotoMono**.
 ![Example of RobotoMono text](static/img/RobotoMono.png)
 
 You can download it from [Google fonts](https://fonts.google.com/specimen/Roboto+Mono).
+
+### Why does the color and the size parameter of a `TextDrawing` has no impact ?
+
+Color and size of the TextDrawing are two features that will be enabled in the future. For now, those are only there to help developers to prepare their developments with this feature.

--- a/example/example.dart
+++ b/example/example.dart
@@ -25,7 +25,7 @@ class _GYWExampleScreenState extends State<GYWExampleScreen> {
 
   Future<void> _sendExampleData() async {
     const List<GYWDrawing> drawings = <GYWDrawing>[
-      WhiteScreen(),
+      BlankScreen(color: "ffffffff"),
       IconDrawing(GYWIcon.up, top: 50, left: 60),
       TextDrawing(
         text: "Hello world",

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -5,7 +5,7 @@ library flutter_gyw;
 export 'src/bt_device.dart' show GYWBtDevice;
 export 'src/bt_manager.dart' show GYWBtManager;
 export 'src/drawings.dart'
-    show GYWDrawing, TextDrawing, WhiteScreen, IconDrawing;
+    show GYWDrawing, TextDrawing, BlankScreen, IconDrawing;
 export 'src/exceptions.dart' show GYWException, GYWStatusException;
 export 'src/fonts.dart' show GYWFont;
 export 'src/icons.dart' show GYWIcon;

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -29,6 +29,8 @@ abstract class GYWDrawing {
         return TextDrawing.fromJson(data);
       case WhiteScreen.type:
         return WhiteScreen.fromJson(data);
+      case BlankScreen.type:
+        return BlankScreen.fromJson(data);
       case IconDrawing.type:
         return IconDrawing.fromJson(data);
       default:
@@ -160,10 +162,18 @@ class TextDrawing extends GYWDrawing {
 }
 
 /// A drawing to reset the screen of the aRdent device to a white screen
+@Deprecated(
+  "WhiteScreen have been replaced by BlankScreen "
+  "who have a variable background color",
+)
 class WhiteScreen extends GYWDrawing {
   /// Type of the [WhiteScreen] drawing
   static const String type = "white_screen";
 
+  @Deprecated(
+    "WhiteScreen have been replaced by BlankScreen "
+    "who have a variable background color",
+  )
   const WhiteScreen();
 
   @override
@@ -182,6 +192,10 @@ class WhiteScreen extends GYWDrawing {
   }
 
   /// Deserialize a [WhiteScreen] from JSON data
+  @Deprecated(
+    "WhiteScreen have been replaced by BlankScreen "
+    "who have a variable background color",
+  )
   // ignore: avoid_unused_constructor_parameters
   factory WhiteScreen.fromJson(Map<String, dynamic> data) {
     return const WhiteScreen();
@@ -193,6 +207,67 @@ class WhiteScreen extends GYWDrawing {
       "type": type,
     };
   }
+}
+
+// A drawing to reset the content of the screen and its background color
+class BlankScreen extends GYWDrawing {
+  /// Type of the [BlankScreen] drawing
+  static const String type = "blank_screen";
+
+  /// Hexadecimal code of the background color
+  final String? color;
+
+  const BlankScreen({this.color});
+
+  @override
+  List<GYWBtCommand> toCommands() {
+    final controlBytes = BytesBuilder();
+    controlBytes.add(int8Bytes(GYWControlCode.clear.value));
+
+    if (color != null) {
+      // Add color value
+      controlBytes.add(utf8.encode(color!));
+    }
+
+    return [
+      GYWBtCommand(
+        GYWCharacteristic.ctrlDisplay,
+        controlBytes.toBytes(),
+      )
+    ];
+  }
+
+  @override
+  String toString() {
+    return "Drawing: blank screen";
+  }
+
+  /// Deserialize a [BlankScreen] from JSON data
+  factory BlankScreen.fromJson(Map<String, dynamic> data) {
+    return BlankScreen(
+      color: data["color"] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      "type": type,
+      "color": color,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is BlankScreen) {
+      return color == other.color;
+    } else {
+      return false;
+    }
+  }
+
+  @override
+  int get hashCode => 23 * color.hashCode;
 }
 
 /// A drawing to display an icon on an aRdent device

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -52,9 +52,17 @@ class TextDrawing extends GYWDrawing {
   /// If no font is given, it uses the most recent one
   final GYWFont? font;
 
+  /// size of the text (max 48 pt)
+  final int? size;
+
+  /// color of the text (in 8-characters ORGB format)
+  final String? color;
+
   const TextDrawing({
     required this.text,
     this.font,
+    this.size,
+    this.color,
     super.left = 0,
     super.top = 0,
   });
@@ -96,7 +104,9 @@ class TextDrawing extends GYWDrawing {
       return text == other.text &&
           left == other.left &&
           top == other.top &&
-          font == other.font;
+          font == other.font &&
+          size == other.size &&
+          color == other.color;
     } else {
       return false;
     }
@@ -107,7 +117,9 @@ class TextDrawing extends GYWDrawing {
       37 * text.hashCode +
       23 * font.hashCode +
       51 * left.hashCode +
-      13 * top.hashCode;
+      13 * top.hashCode +
+      19 * size.hashCode +
+      41 * color.hashCode;
 
   /// Deserialize a [TextDrawing] from JSON data
   factory TextDrawing.fromJson(Map<String, dynamic> data) {
@@ -126,6 +138,8 @@ class TextDrawing extends GYWDrawing {
       // Deprecated: "text" key will be deprecated in future version
       text: data["data"] as String? ?? data["text"] as String,
       font: font,
+      size: data["size"] as int?,
+      color: data["color"] as String?,
     );
   }
 
@@ -139,6 +153,8 @@ class TextDrawing extends GYWDrawing {
       // Deprecated: "text" key will be deprecated in future version
       "text": text,
       if (font != null) "font": font!.index,
+      "size": size,
+      "color": color,
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_gyw
-version: 1.1.1
+version: 1.1.2
 
 publish_to: none
 
@@ -12,13 +12,13 @@ environment:
   flutter: '>=1.17.0'
 
 dependencies:
-  flutter_blue_plus: ^1.3.1
+  flutter_blue_plus: ^1.5.2
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^2.0.0
-  dartdoc: ^6.1.1
+  flutter_lints: ^2.0.1
+  dartdoc: ^6.2.2
   flutter_test:
     sdk: flutter
 

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -5,8 +5,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group("JSON", () {
-    test('white screen', () {
-      const GYWDrawing drawing = WhiteScreen();
+    test('blank screen w/o color', () {
+      const GYWDrawing drawing = BlankScreen();
+
+      expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
+    });
+
+    test('blank screen w/ color', () {
+      const GYWDrawing drawing = BlankScreen(color: "ffff0000");
 
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });


### PR DESCRIPTION
This PR adds the possibility to change the background color of the screen.
To do so,  `WhiteScreen` objects are replaced by `BlankScreen` with a color parameter. This parameter (optional) describes the color to use as background. If not specified, it remains the same as before.

Note : This feature will only work from firmware 1.1.5