### PR TITLE
Add a method to read the firmware version of the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [ADD] Add size and color parameters to TextDrawing
 * [ADD] Convert WhiteScreen into BlankScreen with a color parameter
 * [FIX] Upgrade flutter_blue_plus version
+* [ADD] Add a method to read the firmware version
 
 ## 1.1.1
 * [IMP] Integrate font in text control instruction

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -7,6 +7,7 @@ export 'src/bt_manager.dart' show GYWBtManager;
 export 'src/drawings.dart'
     show GYWDrawing, TextDrawing, BlankScreen, IconDrawing;
 export 'src/exceptions.dart' show GYWException, GYWStatusException;
+export 'src/firmware_version.dart' show FirmwareVersion;
 export 'src/fonts.dart' show GYWFont;
 export 'src/icons.dart' show GYWIcon;
 export 'src/screen.dart' show GYWScreenParameters;

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart' as fb;
 import 'package:flutter_gyw/flutter_gyw.dart';
+import 'package:flutter_gyw/src/firmware_version.dart';
 
 import 'commands.dart';
 import 'helpers.dart';
@@ -243,7 +244,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
   /// Enable or disable the screen autorotation
   Future<void> autoRotateScreen(
-      bool enable,
+    bool enable,
   ) async {
     final controlBytes = BytesBuilder()
       ..addByte(GYWControlCode.autoRotateScreen.value)
@@ -311,6 +312,26 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     );
 
     _screenOn = true;
+  }
+
+  /// Get the firmware version
+  Future<FirmwareVersion> getFirmwareVersion() async {
+    final fb.BluetoothCharacteristic? characteristic =
+    await _findCharacteristic(GYWCharacteristic.firmwareVersion.uuid);
+    if (characteristic == null) {
+      throw GYWException(
+          "Bluetooth characteristic ${GYWCharacteristic.firmwareVersion.uuid} not found");
+    }
+    final List<int> bytes = await characteristic.read();
+    String version = utf8.decode(bytes);
+    version = version.substring(0, version.length - 1); // remove null terminator
+    final List<String> parts = version.split(".");
+
+    return FirmwareVersion(
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+      int.parse(parts[2]),
+    );
   }
 
   /// Compare this [GYWBtDevice] to another based on signal strength

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -6,7 +6,10 @@ enum GYWCharacteristic {
   ctrlDisplay("00004c31-0000-1000-8000-00805f9b34fb"),
 
   /// Characteristic to give data to the display
-  nameDisplay("00004c32-0000-1000-8000-00805f9b34fb");
+  nameDisplay("00004c32-0000-1000-8000-00805f9b34fb"),
+
+  /// Characteristic to read the firmware revision string
+  firmwareVersion("00002a26-0000-1000-8000-00805f9b34fb");
 
   /// UUID of the characteristic
   final String uuid;

--- a/lib/src/firmware_version.dart
+++ b/lib/src/firmware_version.dart
@@ -1,0 +1,49 @@
+class FirmwareVersion implements Comparable<FirmwareVersion> {
+  final int major;
+  final int minor;
+  final int patch;
+
+  FirmwareVersion(
+    this.major,
+    this.minor,
+    this.patch,
+  );
+
+  @override
+  int compareTo(FirmwareVersion other) {
+    if (major == other.major) {
+      if (minor == other.minor) {
+        return patch.compareTo(other.patch);
+      }
+      return minor.compareTo(other.minor);
+    }
+    return major.compareTo(other.major);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FirmwareVersion &&
+          runtimeType == other.runtimeType &&
+          major == other.major &&
+          minor == other.minor &&
+          patch == other.patch;
+
+  @override
+  int get hashCode => major.hashCode ^ minor.hashCode ^ patch.hashCode;
+
+  @override
+  String toString() {
+    return "$major.$minor.$patch";
+  }
+}
+
+extension Compare<T> on Comparable<T> {
+  bool operator >(T other) => compareTo(other) > 0;
+
+  bool operator <(T other) => compareTo(other) < 0;
+
+  bool operator >=(T other) => compareTo(other) >= 0;
+
+  bool operator <=(T other) => compareTo(other) <= 0;
+}


### PR DESCRIPTION
Add a new method that reads the firmware version of the device. The value returned by the function is a FirmwareVersion object that has 3 integers, the major, the minor, and the patch versions. FirmwareVersions can be compared between them using comparison operators.

The firmware version is read from the firmware revision string characteristic from the following service:
https://www.bluetooth.com/specifications/specs/device-information-service/