### PR TITLE
Support custom icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.1.3
-* [FIX] Handle icons that are not recognized
+* [IMP] Support custom icons
 
 ## 1.1.2
 * [ADD] Add size and color parameters to TextDrawing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.3
+* [FIX] Handle icons that are not recognized
+
 ## 1.1.2
 * [ADD] Add size and color parameters to TextDrawing
 * [ADD] Convert WhiteScreen into BlankScreen with a color parameter

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ For now, only a few 48x48 icons are supported. New icons and different sizes wil
 ### What is a "custom" IconDrawing?
 
 A custom `IconDrawing` is an icon that is not part of the default set of icons provided by the package.
-Custom icons must also be 48x48.
+Custom icons will be shown on the GYW device if it contains the corresponding icon file in its internal storage.
+They must also be 48x48.
 
 ### How can I troubleshoot connection issues with my GYW device?
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Note that through this drawing, you can change the background color.
 
 For now, only a few 48x48 icons are supported. New icons and different sizes will be added in future versions.
 
+### What is a "custom" IconDrawing?
+
+A custom `IconDrawing` is an icon that is not part of the default set of icons provided by the package.
+Custom icons must also be 48x48.
+
 ### How can I troubleshoot connection issues with my GYW device?
 
 If you encounter issues with connecting to your GYW device, here are a few things you can try:

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -278,14 +278,14 @@ class IconDrawing extends GYWDrawing {
   bool get isCustom => icon == null;
   
   /// Filename of the icon.
-  String get iconName => icon?.filename ?? customIconName!;
+  String get iconFilename => icon?.filename ?? customIconFilename!;
 
   /// The displayed icon
   final GYWIcon? icon;
 
   /// If [icon] is null, this is a custom icon the library doesn't know about.
   /// The name of this icon will be stored in this field instead.
-  final String? customIconName;
+  final String? customIconFilename;
 
   /// Hexadecimal code of the icon fill color
   final String? color;
@@ -295,10 +295,10 @@ class IconDrawing extends GYWDrawing {
     super.top,
     super.left,
     this.color,
-  }) : customIconName = null;
+  }) : customIconFilename = null;
 
   const IconDrawing.custom(
-    String this.customIconName, {
+    String this.customIconFilename, {
     super.top,
     super.left,
     this.color,
@@ -319,8 +319,7 @@ class IconDrawing extends GYWDrawing {
     return <GYWBtCommand>[
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
-        const Utf8Encoder()
-            .convert("${icon?.filename ?? customIconName}.bin"),
+        const Utf8Encoder().convert("$iconFilename.bin"),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
@@ -331,7 +330,7 @@ class IconDrawing extends GYWDrawing {
 
   @override
   String toString() {
-    return "Drawing: ${icon?.name ?? customIconName} at ($left, $top)";
+    return "Drawing: ${icon?.name ?? customIconFilename} at ($left, $top)";
   }
 
   @override
@@ -386,8 +385,8 @@ class IconDrawing extends GYWDrawing {
       "left": left,
       "top": top,
       // Deprecated: "icon" key will be deprecated in future versions
-      "icon": icon?.name ?? customIconName,
-      "data": icon?.filename ?? customIconName,
+      "icon": icon?.name ?? customIconFilename,
+      "data": iconFilename,
       "color": color,
     };
   }

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -275,15 +275,17 @@ class IconDrawing extends GYWDrawing {
   /// Type of the [IconDrawing]
   static const String type = "icon";
 
+  bool get isCustom => icon == null;
+  
   /// Filename of the icon.
-  String get iconName => icon?.filename ?? _unknownIconName!;
+  String get iconName => icon?.filename ?? customIconName!;
 
   /// The displayed icon
   final GYWIcon? icon;
 
-  /// If [icon] is null, this is a new icon the library doesn't know about.
+  /// If [icon] is null, this is a custom icon the library doesn't know about.
   /// The name of this icon will be stored in this field instead.
-  final String? _unknownIconName;
+  final String? customIconName;
 
   /// Hexadecimal code of the icon fill color
   final String? color;
@@ -293,10 +295,10 @@ class IconDrawing extends GYWDrawing {
     super.top,
     super.left,
     this.color,
-  }) : _unknownIconName = null;
+  }) : customIconName = null;
 
-  const IconDrawing._unknown(
-    this._unknownIconName, {
+  const IconDrawing.custom(
+    String this.customIconName, {
     super.top,
     super.left,
     this.color,
@@ -318,7 +320,7 @@ class IconDrawing extends GYWDrawing {
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
         const Utf8Encoder()
-            .convert("${icon?.filename ?? _unknownIconName}.bin"),
+            .convert("${icon?.filename ?? customIconName}.bin"),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
@@ -329,7 +331,7 @@ class IconDrawing extends GYWDrawing {
 
   @override
   String toString() {
-    return "Drawing: ${icon?.name ?? _unknownIconName} at ($left, $top)";
+    return "Drawing: ${icon?.name ?? customIconName} at ($left, $top)";
   }
 
   @override
@@ -368,7 +370,7 @@ class IconDrawing extends GYWDrawing {
         color: data["color"] as String?,
       );
     } else {
-      return IconDrawing._unknown(
+      return IconDrawing.custom(
         icon,
         left: data["left"] as int,
         top: data["top"] as int,
@@ -384,8 +386,8 @@ class IconDrawing extends GYWDrawing {
       "left": left,
       "top": top,
       // Deprecated: "icon" key will be deprecated in future versions
-      "icon": icon?.name ?? _unknownIconName,
-      "data": icon?.filename ?? _unknownIconName,
+      "icon": icon?.name ?? customIconName,
+      "data": icon?.filename ?? customIconName,
       "color": color,
     };
   }

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -275,6 +275,9 @@ class IconDrawing extends GYWDrawing {
   /// Type of the [IconDrawing]
   static const String type = "icon";
 
+  /// Filename of the icon.
+  String get iconName => icon?.filename ?? _unknownIconName!;
+
   /// The displayed icon
   final GYWIcon? icon;
 


### PR DESCRIPTION
Some use cases require custom icons that are not necessarily part of the library. Before this change, theses custom icons blocked the entire deserialization process. They are now supported, and the icon will be sent correctly to the glasses.
This change also fixes the problem of an app that is not synchronous with the last icon library updates.