### PR TITLE
Deprecate the set font command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.3
 * [DEL] Deprecate delays when sending commands and set their default value to 0
 * [IMP] Support custom icons
+* [DEL] Deprecate the `setFont` function and send font size and color through Bluetooth
 
 ## 1.1.2
 * [ADD] Add size and color parameters to TextDrawing

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -221,6 +221,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   }
 
   /// Set the default font on the aRdent to display the next [TextDrawing]
+  @Deprecated("Set the font when drawing text with `TextDrawing`")
   Future<void> setFont(
     GYWFont font, {
     @Deprecated("Delay is no longer needed") int delay = 0,

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -78,10 +78,14 @@ class TextDrawing extends GYWDrawing {
     controlBytes.add(int32Bytes(left));
     controlBytes.add(int32Bytes(top));
 
-    // Add font
-    if (font != null) {
-      controlBytes.add(utf8.encode(font!.prefix));
+    controlBytes.add(utf8.encode(font?.prefix ?? "NUL"));
+    controlBytes.add(int8Bytes(size ?? 0));
+
+    String shortColor = "NULL";
+    if (color != null) {
+      shortColor = color![0] + color![2] + color![4] + color![6];
     }
+    controlBytes.add(utf8.encode(shortColor));
 
     return [
       GYWBtCommand(
@@ -276,7 +280,7 @@ class IconDrawing extends GYWDrawing {
   static const String type = "icon";
 
   bool get isCustom => icon == null;
-  
+
   /// Filename of the icon.
   String get iconFilename => icon?.filename ?? customIconFilename!;
 


### PR DESCRIPTION
`TextDrawing` can be used to specify the font size and color, and now it also sends these properties to the device through Bluetooth.