### PR TITLE
Improve code documentation

### DIFF
--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -1,0 +1,29 @@
+name: Flutter lints & tests
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop 
+
+jobs:
+  lint_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+
+    - name: Install dependencies
+      run: flutter pub get
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Run linter
+      run: flutter analyze
+
+    - name: Run tests
+      run: flutter test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [IMP] Support custom icons
 * [DEL] Deprecate the `setFont` function and send font size and color through Bluetooth
 * [ADD] Add SVG icons and scaling factor
+* [IMP] Improve code documentation
 
 ## 1.1.2
 * [ADD] Add size and color parameters to TextDrawing

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,7 @@
 analyzer:
   language:
     strict-casts: true
+    strict-inference: true
     strict-raw-types: true
   errors:
     # allow self-reference to deprecated members (we do this because otherwise we have
@@ -10,16 +11,20 @@ analyzer:
     - "bin/cache/**"
       # Ignore protoc generated files
     - "dev/conductor/lib/proto/*"
+    # Ignore generated files
+    - '**/*.g.dart'
+    - '**/*.mocks.dart' # Mockito @GenerateMocks
 
 linter:
   rules:
     # This list is derived from the list of all available lints located at
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    # It is mainly inspired by packages lints in Flutter (https://github.com/flutter/packages/blob/main/analysis_options.yaml)
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
     - always_require_non_null_named_parameters
-    # - always_specify_types
+    # - always_specify_types # only public types must be specified (type_annotate_public_apis)
     # - always_use_package_imports # we do this commonly
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
@@ -30,6 +35,7 @@ linter:
     - avoid_double_and_int_checks
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
     # - avoid_final_parameters # incompatible with prefer_final_parameters
@@ -69,6 +75,7 @@ linter:
     - cast_nullable_to_non_nullable
     # - close_sinks # not reliable enough
     - collection_methods_unrelated_type
+    # - combinators_ordering # DIFFERENT FROM FLUTTER/FLUTTER: This isn't available on stable yet.
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
     - conditional_uri_does_not_exist
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
@@ -78,7 +85,7 @@ linter:
     - deprecated_consistency
     # - diagnostic_describe_all_properties # enabled only at the framework level (packages/flutter/lib)
     - directives_ordering
-    # - discarded_futures # too many false positives, similar to unawaited_futures
+    # - discarded_futures # not yet tested
     # - do_not_use_environment # there are appropriate times to use the environment, especially in our tests and build logic
     - empty_catches
     - empty_constructor_bodies
@@ -86,6 +93,7 @@ linter:
     - eol_at_end_of_file
     - exhaustive_cases
     - file_names
+    - flutter_style_todos
     - hash_and_equals
     - implementation_imports
     # - join_return_with_assignment # not required by flutter style
@@ -102,7 +110,7 @@ linter:
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
     - no_logic_in_create_state
-    # - no_runtimeType_toString # ok in tests; we enable this only in packages/
+    - no_runtimeType_toString # DIFFERENT FROM FLUTTER/FLUTTER
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
@@ -146,7 +154,7 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
-    # - prefer_mixin # has false positives, see https://github.com/dart-lang/linter/issues/3018
+    # - prefer_mixin # Has false positives, see https://github.com/dart-lang/linter/issues/3018
     # - prefer_null_aware_method_calls # "call()" is confusing to people new to the language since it's not documented anywhere
     - prefer_null_aware_operators
     # - prefer_relative_imports
@@ -155,23 +163,23 @@ linter:
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null
     - provide_deprecation_message
-    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    # - public_member_api_docs # DIFFERENT FROM FLUTTER/FLUTTER
     - recursive_getters
-    # - require_trailing_commas # would be nice, but requires a lot of manual work: 10,000+ code locations would need to be reformatted by hand after bulk fix is applied
+    - require_trailing_commas
     - secure_pubspec_urls
     - sized_box_for_whitespace
-    - sized_box_shrink_expand
+    # - sized_box_shrink_expand # not yet tested
     - slash_for_doc_comments
     - sort_child_properties_last
     # - sort_constructors_first
-    # - sort_pub_dependencies # prevents separating pinned transitive dependencies
+    - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally
     - tighten_type_of_initializing_formals
-    # - type_annotate_public_apis # subset of always_specify_types
+    - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # too many false positives, especially with the way AnimationController works
+    - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
@@ -194,12 +202,11 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
-    # - unreachable_from_main # Do not enable this rule until it is un-marked as "experimental" and carefully re-evaulated.
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
-    - use_colored_box
-    # - use_decorated_box # leads to bugs: DecoratedBox and Container are not equivalent (Container inserts extra padding)
+    # - use_colored_box # not yet tested
+    # - use_decorated_box # not yet tested
     - use_enums
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -2,7 +2,7 @@
 ///
 /// The aRdent smart glasses are developed by Get Your Way. They can be seen
 /// as a Head-Up Display (HUD) on which are shown drawings (icons, texts, ...).
-/// This library can be use to control the display.
+/// This library can be used to control the display.
 library flutter_gyw;
 
 export 'src/bt_device.dart' show GYWBtDevice;

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -1,11 +1,14 @@
-/// This library provides an interface between a Flutter application and
-/// Get Your Way devices like the aRdent smart glasses.
+/// This library provides a Flutter interface with aRdent glasses developed.
+///
+/// The aRdent smart glasses are developed by Get Your Way. They can be seen
+/// as a Head-Up Display (HUD) on which are shown drawings (icons, texts, ...).
+/// This library can be use to control the display.
 library flutter_gyw;
 
 export 'src/bt_device.dart' show GYWBtDevice;
 export 'src/bt_manager.dart' show GYWBtManager;
 export 'src/drawings.dart'
-    show GYWDrawing, TextDrawing, BlankScreen, IconDrawing;
+    show BlankScreen, GYWDrawing, IconDrawing, TextDrawing;
 export 'src/exceptions.dart' show GYWException, GYWStatusException;
 export 'src/fonts.dart' show GYWFont;
 export 'src/icons.dart' show GYWIcon;

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -10,12 +10,12 @@ import 'package:flutter_gyw/flutter_gyw.dart';
 import 'commands.dart';
 import 'helpers.dart';
 
-/// Representation of a Bluetooth device
+/// The representation of a Bluetooth device in the library
 class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
-  /// Encapsulated FlutterBluePlus device
+  /// The encapsulated FlutterBluePlus device
   fb.BluetoothDevice fbDevice;
 
-  /// Time when the device was last detected
+  /// The time when the device was last detected
   late DateTime lastSeen;
 
   bool _isConnecting = false;
@@ -23,27 +23,21 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   bool _isConnected = false;
   bool _screenOn = false;
 
-  /// Status value indicating that a connection to the device is in progress
+  /// Whether the connection to the device is in progress
   bool get isConnecting => _isConnecting;
 
-  /// Status value indicating that a connection to the device is in progress
+  /// Whether the disconnection to the device is in progress
   bool get isDisconnecting => _isDisconnecting;
 
-  /// Status value indicating that the device is connected
+  /// Whether the device is connected
   bool get isConnected => _isConnected;
-
-  /// Most recently used font (used for the optimisation of [TextDrawing])
-  GYWFont? font;
-
-  /// Enable font optimisation
-  bool fontOptimized = true;
 
   late int _lastRssi;
 
-  /// Strength of the signal when the device was last detected
-  int get lastRssi => _lastRssi;
-
+  /// The strength of the signal when the device was last detected
+  ///
   /// By setting the lastRssi, the lastSeen value is also updated
+  int get lastRssi => _lastRssi;
   set lastRssi(int lastRssi) {
     _lastRssi = lastRssi;
     lastSeen = DateTime.now();
@@ -66,13 +60,15 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Name of the device
-  String get name => fbDevice.localName;
+  /// The name of the device
+  String get name => fbDevice.platformName;
 
-  /// UUID of the device
+  /// The MAC address (or the public UUID) of the device
   String get id => fbDevice.remoteId.str;
 
-  /// Connect the Bluetooth device to the current device
+  /// Connects the Bluetooth device to the current device
+  ///
+  /// The method returns `true` if the operation is successful, false otherwise
   Future<bool> connect() async {
     if (isConnecting) {
       throw const GYWStatusException(
@@ -115,7 +111,9 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     return isConnected;
   }
 
-  /// Disconnect the Bluetooth device
+  /// Disconnects the Bluetooth device
+  ///
+  /// The method returns `true` if the operation is successful, false otherwise
   Future<bool> disconnect() async {
     if (isConnecting) {
       throw const GYWStatusException(
@@ -137,9 +135,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
     // Clear saved characteristics
     _characteristics = <String, fb.BluetoothCharacteristic?>{};
-
-    // Clear font
-    font = null;
 
     try {
       await fbDevice.disconnect();
@@ -179,7 +174,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     return null;
   }
 
-  /// Send data to the aRdent device to display a [GYWDrawing]
+  /// Sends data to the aRdent device to display a [GYWDrawing]
   Future<void> sendDrawing(
     GYWDrawing drawing, {
     @Deprecated("Delay is no longer needed") int delay = 0,
@@ -189,17 +184,12 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     for (final GYWBtCommand command in commands) {
       await _sendBTCommand(command);
       if (delay != 0) {
-        await Future.delayed(Duration(milliseconds: delay));
+        await Future<void>.delayed(Duration(milliseconds: delay));
       }
-    }
-
-    // Save current font
-    if (drawing is TextDrawing && drawing.font != null) {
-      font = drawing.font;
     }
   }
 
-  /// Send data to the aRdent device to display a [GYWDrawing]
+  /// Sends data to the aRdent device to display a [GYWDrawing]
   @Deprecated("This method is going to be replaced by sendDrawing")
   Future<void> displayDrawing(
     GYWDrawing drawing, {
@@ -210,17 +200,12 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     for (final GYWBtCommand command in commands) {
       await _sendBTCommand(command);
       if (delay != 0) {
-        await Future.delayed(Duration(milliseconds: delay));
+        await Future<void>.delayed(Duration(milliseconds: delay));
       }
-    }
-
-    // Save current font
-    if (drawing is TextDrawing && drawing.font != null) {
-      font = drawing.font;
     }
   }
 
-  /// Set the default font on the aRdent to display the next [TextDrawing]
+  /// Sets the default font on the aRdent to display the next [TextDrawing]
   @Deprecated("Set the font when drawing text with `TextDrawing`")
   Future<void> setFont(
     GYWFont font, {
@@ -240,15 +225,14 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     for (final GYWBtCommand command in commands) {
       await _sendBTCommand(command);
       if (delay != 0) {
-        await Future.delayed(Duration(milliseconds: delay));
+        await Future<void>.delayed(Duration(milliseconds: delay));
       }
     }
-
-    // Save font
-    this.font = font;
   }
 
-  /// Set the screen brightness. The value must be between 0 and 1.
+  /// Sets the screen brightness.
+  ///
+  /// The value must be between 0 and 1.
   Future<void> setBrightness(
     double value, {
     @Deprecated("Delay is no longer needed") int delay = 0,
@@ -266,11 +250,13 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
     await _sendBTCommand(command);
     if (delay != 0) {
-      await Future.delayed(Duration(milliseconds: delay));
+      await Future<void>.delayed(Duration(milliseconds: delay));
     }
   }
 
-  /// Set the screen brightness. The value must be between 0 and 1.
+  /// Sets the screen contrast.
+  ///
+  /// The value must be between 0 and 1.
   Future<void> setContrast(
     double value, {
     @Deprecated("Delay is no longer needed") int delay = 0,
@@ -288,11 +274,11 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
     await _sendBTCommand(command);
     if (delay != 0) {
-      await Future.delayed(Duration(milliseconds: delay));
+      await Future<void>.delayed(Duration(milliseconds: delay));
     }
   }
 
-  /// Enable or disable the screen autorotation
+  /// Enables or disables the screen autorotation.
   Future<void> autoRotateScreen(
     bool enable,
   ) async {
@@ -318,7 +304,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Write data on a Bluetooth characteristic by chunk of 20 bytes
+  /// Writes data on a Bluetooth characteristic by chunk of 20 bytes
   Future<void> _sendData(
     fb.BluetoothCharacteristic characteristic,
     Uint8List data,
@@ -342,7 +328,9 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Turn the screen on
+  /// Turns the screen on and initialize it for future drawings.
+  ///
+  /// This method must be called once before performing display operations.
   Future<void> startDisplay({
     @Deprecated("Delay is no longer needed") int delay = 0,
   }) async {
@@ -358,13 +346,13 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
     await _sendBTCommand(command);
     if (delay != 0) {
-      await Future.delayed(Duration(milliseconds: delay));
+      await Future<void>.delayed(Duration(milliseconds: delay));
     }
 
     _screenOn = true;
   }
 
-  /// Turn the display backlight on or off
+  /// Turns the display backlight on or off
   Future<void> enableBacklight(
     bool enable,
   ) async {
@@ -379,7 +367,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     await _sendBTCommand(command);
   }
 
-  /// Compare this [GYWBtDevice] to another based on signal strength
+  /// Compares this [GYWBtDevice] to another based on signal strength
   @override
   int compareTo(GYWBtDevice? other) {
     return -lastRssi.compareTo(other?.lastRssi ?? -1);

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -304,7 +304,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Writes data on a Bluetooth characteristic by chunk of 20 bytes
+  /// Writes data on a Bluetooth characteristic by chunks of 20 bytes
   Future<void> _sendData(
     fb.BluetoothCharacteristic characteristic,
     Uint8List data,
@@ -328,7 +328,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Turns the screen on and initialize it for future drawings.
+  /// Turns the screen on and initializes it for future drawings.
   ///
   /// This method must be called once before performing display operations.
   Future<void> startDisplay({

--- a/lib/src/bt_manager.dart
+++ b/lib/src/bt_manager.dart
@@ -9,10 +9,10 @@ class GYWBtManager {
   static final GYWBtManager instance = GYWBtManager._();
 
   GYWBtManager._() {
-    init();
+    _init();
   }
 
-  Future<void> init() async {
+  Future<void> _init() async {
     bluetoothOn = await bluetoothOnAsync;
 
     FlutterBluePlus.adapterState.listen((state) {
@@ -25,19 +25,19 @@ class GYWBtManager {
     });
   }
 
-  /// List of devices available for a Bluetooth connection
+  /// The list of devices available for a Bluetooth connection
   List<GYWBtDevice> devices = [];
 
-  /// Status value indicating that the manager is searching around for devices
+  /// whether the manager is searching around for devices
   bool _isScanning = false;
 
-  /// Whether the Bluetooth is on
+  /// Whether the Bluetooth is active
   bool bluetoothOn = false;
 
-  /// Function triggered when there is a Bluetooth status change
+  /// A function triggered when there is a Bluetooth status change
   void Function(bool)? onBluetoothStatusChange;
 
-  /// Manullay refresh the Bluetooth status and returns the new status
+  /// Manullay refreshes the Bluetooth status and returns the new status
   Future<bool> get bluetoothOnAsync async {
     final BluetoothAdapterState bluetoothState =
         await FlutterBluePlus.adapterState.first;
@@ -59,7 +59,10 @@ class GYWBtManager {
     }
   }
 
-  /// Scan for Bluetooth devices and refresh the list of devices available for a connection
+  /// Scans for Bluetooth devices in the surroundings
+  ///
+  /// This refreshes the list of devices available for a connection and throws
+  /// [GYWStatusException] in case of error
   Future<void> refreshDevices({
     Duration timeout = const Duration(seconds: 3),
     int deviceLifeDuration = 10,
@@ -78,7 +81,7 @@ class GYWBtManager {
       _isScanning = true;
 
       // Get devices that are already connected
-      final connectedDevices = await FlutterBluePlus.connectedSystemDevices;
+      final connectedDevices = await FlutterBluePlus.systemDevices;
 
       // Add them to the manager list
       for (final BluetoothDevice fbDevice in connectedDevices) {
@@ -152,8 +155,9 @@ class GYWBtManager {
     }
   }
 
-  /// Stop the current scan.
-  /// Throws a [GYWStatusException] if a scan is not in progress
+  /// Stops the current scan
+  ///
+  /// It throws a [GYWStatusException] if a scan is not in progress
   Future<void> stopScan() async {
     if (!_isScanning) {
       throw const GYWStatusException("Scan is not in progress.");

--- a/lib/src/bt_manager.dart
+++ b/lib/src/bt_manager.dart
@@ -37,7 +37,7 @@ class GYWBtManager {
   /// A function triggered when there is a Bluetooth status change
   void Function(bool)? onBluetoothStatusChange;
 
-  /// Manullay refreshes the Bluetooth status and returns the new status
+  /// Manually refreshes the Bluetooth status and returns the new status
   Future<bool> get bluetoothOnAsync async {
     final BluetoothAdapterState bluetoothState =
         await FlutterBluePlus.adapterState.first;

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -8,7 +8,7 @@ enum GYWCharacteristic {
   /// Characteristic to give data to the display
   nameDisplay("00004c32-0000-1000-8000-00805f9b34fb");
 
-  /// UUID of the characteristic
+  /// The UUID of the characteristic
   final String uuid;
 
   const GYWCharacteristic(this.uuid);
@@ -43,18 +43,18 @@ enum GYWControlCode {
   /// Enable or disable the display backlight
   enableBacklight(0x0B);
 
-  /// Control code value used internally on the device
+  /// The Control code value used internally on the device
   final int value;
 
   const GYWControlCode(this.value);
 }
 
-/// A representation of a Bluetooth operation to apply
+/// A representation of a Bluetooth write operation to apply
 class GYWBtCommand {
-  /// Bluetooth characteristic
+  /// The Bluetooth characteristic on which to write some data
   final GYWCharacteristic characteristic;
 
-  /// Data to write on the characteristic
+  /// The data to write on the characteristic
   final Uint8List data;
 
   const GYWBtCommand(this.characteristic, this.data);

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -11,7 +11,7 @@ import 'icons.dart';
 /// A drawing that can be displayed on a pair of aRdent smart glasses
 @immutable
 abstract class GYWDrawing {
-  /// The distances (in pixels) from the top of the screen
+  /// The distance (in pixels) from the top of the screen
   final int top;
 
   /// The distance (in pixels) from the left side of the screen
@@ -48,7 +48,7 @@ abstract class GYWDrawing {
 /// A drawing to display text on an aRdent device
 @immutable
 class TextDrawing extends GYWDrawing {
-  /// The type of a [TextDrawing] drawing
+  /// The type of the [TextDrawing] drawing
   static const String type = "text";
 
   /// The text that must be displayed

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -1,17 +1,20 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:flutter/material.dart';
+
 import 'commands.dart';
 import 'fonts.dart';
 import 'helpers.dart';
 import 'icons.dart';
 
 /// A drawing that can be displayed on a pair of aRdent smart glasses
+@immutable
 abstract class GYWDrawing {
-  /// Distance (in pixels) from the top
+  /// The distances (in pixels) from the top of the screen
   final int top;
 
-  /// Distance (in pixels) from the left side
+  /// The distance (in pixels) from the left side of the screen
   final int left;
 
   const GYWDrawing({
@@ -19,7 +22,7 @@ abstract class GYWDrawing {
     this.left = 0,
   });
 
-  /// Convert the drawing into a list of commands understood by the device
+  /// Converts the drawing into a list of commands understood by the device
   List<GYWBtCommand> toCommands();
 
   /// Deserializes a [GYWDrawing] from JSON data
@@ -43,21 +46,23 @@ abstract class GYWDrawing {
 }
 
 /// A drawing to display text on an aRdent device
+@immutable
 class TextDrawing extends GYWDrawing {
-  /// Type of a [TextDrawing] drawing
+  /// The type of a [TextDrawing] drawing
   static const String type = "text";
 
-  /// Displayed text
+  /// The text that must be displayed
   final String text;
 
-  /// Font (fontSize, fontWeight, ...) of the text
+  /// The [GYWFont] to use
+  ///
   /// If no font is given, it uses the most recent one
   final GYWFont? font;
 
-  /// size of the text (max 48 pt)
+  /// The size of the text (max 48 pt)
   final int? size;
 
-  /// color of the text (in 8-characters ORGB format)
+  /// The color of the text (in 8-characters ORGB format)
   final String? color;
 
   const TextDrawing({
@@ -127,7 +132,7 @@ class TextDrawing extends GYWDrawing {
       19 * size.hashCode +
       41 * color.hashCode;
 
-  /// Deserialize a [TextDrawing] from JSON data
+  /// Deserializes a [TextDrawing] from JSON data
   factory TextDrawing.fromJson(Map<String, dynamic> data) {
     GYWFont? font;
     try {
@@ -171,7 +176,7 @@ class TextDrawing extends GYWDrawing {
   "who has a variable background color",
 )
 class WhiteScreen extends GYWDrawing {
-  /// Type of the [WhiteScreen] drawing
+  /// The type of the [WhiteScreen] drawing
   static const String type = "white_screen";
 
   @Deprecated(
@@ -186,7 +191,7 @@ class WhiteScreen extends GYWDrawing {
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
         int8Bytes(GYWControlCode.clear.value),
-      )
+      ),
     ];
   }
 
@@ -195,7 +200,7 @@ class WhiteScreen extends GYWDrawing {
     return "Drawing: white screen";
   }
 
-  /// Deserialize a [WhiteScreen] from JSON data
+  /// Deserializes a [WhiteScreen] from JSON data
   @Deprecated(
     "WhiteScreen has been replaced by BlankScreen "
     "who has a variable background color",
@@ -213,12 +218,13 @@ class WhiteScreen extends GYWDrawing {
   }
 }
 
-// A drawing to reset the content of the screen and its background color
+/// A drawing to reset the content of the screen and its background color
+@immutable
 class BlankScreen extends GYWDrawing {
-  /// Type of the [BlankScreen] drawing
+  /// The type of the [BlankScreen] drawing
   static const String type = "blank_screen";
 
-  /// Hexadecimal code of the background color
+  /// The hexadecimal code of the background color
   final String? color;
 
   const BlankScreen({this.color});
@@ -237,7 +243,7 @@ class BlankScreen extends GYWDrawing {
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
         controlBytes.toBytes(),
-      )
+      ),
     ];
   }
 
@@ -246,7 +252,7 @@ class BlankScreen extends GYWDrawing {
     return "Drawing: blank screen";
   }
 
-  /// Deserialize a [BlankScreen] from JSON data
+  /// Deserializes a [BlankScreen] from JSON data
   factory BlankScreen.fromJson(Map<String, dynamic> data) {
     return BlankScreen(
       color: data["color"] as String?,
@@ -275,19 +281,22 @@ class BlankScreen extends GYWDrawing {
 }
 
 /// A drawing to display an icon on an aRdent device
+@immutable
 class IconDrawing extends GYWDrawing {
-  /// Type of the [IconDrawing]
+  /// The type of the [IconDrawing]
   static const String type = "icon";
 
+  /// whether the drawings uses a icon that is not part of the library
   bool get isCustom => icon == null;
 
-  /// Filename of the icon.
+  /// The filename of the icon.
   String get iconFilename => icon?.filename ?? customIconFilename!;
 
-  /// The displayed icon
+  /// The displayed [GYWIcon]
   final GYWIcon? icon;
 
   /// If [icon] is null, this is a custom icon the library doesn't know about.
+  ///
   /// The name of this icon will be stored in this field instead.
   final String? customIconFilename;
 
@@ -295,6 +304,7 @@ class IconDrawing extends GYWDrawing {
   final String? color;
 
   /// The icon scaling factor.
+  ///
   /// Minimum is 0.01, maximum is 13.7.
   final double scale;
 
@@ -306,6 +316,7 @@ class IconDrawing extends GYWDrawing {
     this.scale = 1.0,
   }) : customIconFilename = null;
 
+  /// Creates a custom icon, i.e. an icon whose image is not in the library
   const IconDrawing.custom(
     String this.customIconFilename, {
     super.top,
@@ -346,7 +357,7 @@ class IconDrawing extends GYWDrawing {
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
         controlBytes.toBytes(),
-      )
+      ),
     ];
   }
 
@@ -377,14 +388,15 @@ class IconDrawing extends GYWDrawing {
         scale,
       );
 
-  /// Deserialize an [IconDrawing] from JSON data
+  /// Deserializes an [IconDrawing] from JSON data
   factory IconDrawing.fromJson(Map<String, dynamic> data) {
     // Deprecated "icon" key will be deprecated in future versions
     final String icon = data["data"] as String? ?? data["icon"] as String;
 
     final GYWIcon? gywIcon = GYWIcon.values.cast<GYWIcon?>().firstWhere(
-        (element) => element!.filename == icon || element.name == icon,
-        orElse: () => null);
+          (element) => element!.filename == icon || element.name == icon,
+          orElse: () => null,
+        );
 
     if (gywIcon != null) {
       return IconDrawing(

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,18 +1,22 @@
-/// This type of exception is triggered by this package in case of error
+/// An exception triggered by the package in case of error
 class GYWException implements Exception {
-  /// String describing the cause of the error
+  /// The description of the cause of the error
   final String cause;
 
   const GYWException(this.cause);
 
   @override
   String toString() {
+    // All subtypes are defined in the library, the call is therefore safe
+    // ignore: no_runtimetype_tostring
     return "$runtimeType: $cause";
   }
 }
 
-/// This type of exception is triggered when a method is triggered while an
-/// action is made on a component of this package while it should not.
+/// This exception is triggered when a method is called when it should not.
+///
+/// It is triggered when an action is made on a component while it is not ready
+/// or when another operation is already in progess.
 /// For example, trying to connect a device while a connection is already
 /// in progress
 class GYWStatusException extends GYWException {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -16,7 +16,7 @@ class GYWException implements Exception {
 /// This exception is triggered when a method is called when it should not.
 ///
 /// It is triggered when an action is made on a component while it is not ready
-/// or when another operation is already in progess.
+/// or when another operation is already in progress.
 /// For example, trying to connect a device while a connection is already
 /// in progress
 class GYWStatusException extends GYWException {

--- a/lib/src/fonts.dart
+++ b/lib/src/fonts.dart
@@ -1,23 +1,23 @@
-/// Text fonts supported on aRdent smart glasses
+/// The text fonts supported on aRdent smart glasses
 enum GYWFont {
   small("Small", "a10", 18, 10, 25),
   medium("Medium", "b14", 24, 14, 33, true),
   large("Large", "a16", 28, 16, 39),
   huge("Huge", "b28", 48, 28, 67, true);
 
-  /// Name of the font
+  /// The name of the font
   final String name;
 
-  /// Internal prefix of the font
+  /// The internal prefix of the font
   final String prefix;
 
-  /// Size (in points) of a character
+  /// The size (in points) of a character
   final int size;
 
-  /// Width (in pixels) of a character
+  /// The width (in pixels) of a character
   final int width;
 
-  /// Height (in pixels) of a character
+  /// The height (in pixels) of a character
   final int height;
 
   /// Whether the fontweight is bold (w700) or normal (w400)

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -1,20 +1,20 @@
 import 'dart:typed_data';
 
-/// Convert a int32 into bytes
+/// Converts a int32 into bytes
 Uint8List int32Bytes(
   int value, {
   Endian endian = Endian.little,
 }) =>
     Uint8List(4)..buffer.asByteData().setInt32(0, value, endian);
 
-/// Convert a int8 into bytes
+/// Converts a int8 into bytes
 Uint8List int8Bytes(
   int value, {
   Endian endian = Endian.little,
 }) =>
     Uint8List(1)..buffer.asByteData().setInt8(0, value);
 
-/// Allow to compare Comparable object using inequality signs
+/// Allows to compare Comparable object using inequality signs
 extension Compare<T> on Comparable<T> {
   bool operator >(T other) => compareTo(other) > 0;
 

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -1,4 +1,4 @@
-/// Icons supported by aRdent smart glasses
+/// The icons supported by aRdent smart glasses
 enum GYWIcon {
   gyw("GYW", "GYW", 121, 48),
   down("Down", "down", 48, 48),
@@ -40,16 +40,16 @@ enum GYWIcon {
   key_star("Key *", "key_star", 48, 48),
   key_num("Key #", "key_#", 48, 48);
 
-  /// Name of the icon
+  /// The name of the icon
   final String name;
 
-  /// Filename on the GYW device
+  /// The filename on the GYW device
   final String filename;
 
-  /// Width (in pixels) of the icon
+  /// The width (in pixels) of the icon
   final double width;
 
-  /// Height (in pixels) of the icon
+  /// The height (in pixels) of the icon
   final double height;
 
   const GYWIcon(
@@ -59,8 +59,13 @@ enum GYWIcon {
     this.height,
   );
 
-  /// Path of the associated file in the assets folder
+  /// The path of the associated file in the assets folder
+  @Deprecated("Use pathPng instead")
   String get path => "assets/icons/$filename.png";
 
+  /// The path of the associated PNG file in the assets folder
+  String get pathPng => "assets/icons/$filename.png";
+
+  /// The path of the associated SVG file in the assets folder
   String get pathSvg => "assets/icons/$filename.svg";
 }

--- a/lib/src/screen.dart
+++ b/lib/src/screen.dart
@@ -2,9 +2,9 @@
 class GYWScreenParameters {
   GYWScreenParameters._();
 
-  /// Supported Width of a GYW aRdent device
+  /// The screen width (in pixels) of the aRdent glasses
   static const int width = 854;
 
-  /// Supported Width of a GYW aRdent device
+  /// The screen height (in pixels) of the aRdent glasses
   static const int height = 480;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,13 @@ environment:
   flutter: '>=1.17.0'
 
 dependencies:
-  flutter_blue_plus: ^1.15.5
   flutter:
     sdk: flutter
+  flutter_blue_plus: ^1.15.5
 
 dev_dependencies:
-  flutter_lints: ^2.0.3
   dartdoc: ^6.3.0
+  flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
* Upgrade the lints based on Flutter packages lints
* Add a Github action to automatically run tests and lints
* Improve inline documentation seeing the result of `public_member_api_docs`.

The `public_member_api_docs` lint is not active yet, because every constructor and enum value must be documented.