### PR TITLE
Serialize icon scale also from integers, not only doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [ADD] Add SVG icons and scaling factor
 * [FIX] Replace the old rename PNG icon with the new one
 * [IMP] Improve code documentation
+* [FIX] Make icon scale deserialization work also with integers, not only doubles
 
 ## 1.1.2
 * [ADD] Add size and color parameters to TextDrawing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4
+
+* [FIX] Make icon scale deserialization work also with integers, not only doubles
+
 ## 1.1.3
 * [DEL] Deprecate delays when sending commands and set their default value to 0
 * [IMP] Support custom icons
@@ -6,7 +10,6 @@
 * [FIX] Replace the old rename PNG icon with the new one
 * [IMP] Improve code documentation
 * [IMP] Add support for wrapping TextDrawings on multiple lines
-* [FIX] Make icon scale deserialization work also with integers, not only doubles
 
 ## 1.1.2
 * [ADD] Add size and color parameters to TextDrawing

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -404,7 +404,7 @@ class IconDrawing extends GYWDrawing {
         left: data["left"] as int,
         top: data["top"] as int,
         color: data["color"] as String?,
-        scale: (data["scale"] ?? 1.0) as double,
+        scale: (data["scale"] as num? ?? 1.0).toDouble(),
       );
     } else {
       return IconDrawing.custom(
@@ -412,7 +412,7 @@ class IconDrawing extends GYWDrawing {
         left: data["left"] as int,
         top: data["top"] as int,
         color: data["color"] as String?,
-        scale: (data["scale"] ?? 1.0) as double,
+        scale: (data["scale"] as num? ?? 1.0).toDouble(),
       );
     }
   }


### PR DESCRIPTION
Before this change, the deserialization threw an exception if the scale was an integer and not a double. Now it can be any of those.