### PR TITLE
Add a new drawing for colored rectangles which allows for partially clearing the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.4
 
 * [FIX] Make icon scale deserialization work also with integers, not only doubles
+* [ADD] Add a new drawing for colored rectangles which allows for partially clearing the screen
 
 ## 1.1.3
 * [DEL] Deprecate delays when sending commands and set their default value to 0

--- a/README.md
+++ b/README.md
@@ -105,6 +105,62 @@ for (GYWDrawing drawing in drawings) {
 
 A complete example can be found [here](example/example.dart)
 
+## Drawings
+
+### 1. BlankScreen
+
+Fills the screen with a solid color. If no color is given, the screen will be filled with the last color used, useful for erasing parts of the screen.
+
+```dart
+final drawing = BlankScreen(color: "FF0000FF");
+```
+
+### 2. TextDrawing
+
+Displays text on the screen.
+
+```dart
+final drawing = TextDrawing(
+  text: "Hello, World!",
+  left: 220,
+  top: 50,
+  font: GYWFont.large,
+  size: 34,
+  maxWidth: 200,
+  maxLines: 2,
+);
+```
+
+Look at the documentation for details about each parameter.
+
+### 3. IconDrawing
+
+Displays an icon on the screen.
+
+```dart
+final drawing = IconDrawing(
+  icon: GYWIcon.checkbox,
+  left: 220,
+  top: 50,
+  color: "FF0000FF",
+  scale: 1.5,
+);
+```
+
+### 4. RectangleDrawing
+
+Draws a colored rectangle on the screen.
+
+```dart
+final drawing = RectangleDrawing(
+  left: 220,
+  top: 50,
+  width: 100,
+  height: 100,
+  color: "FF0000FF",
+);
+```
+
 ## Licence
 
 Copyright (c) 2023 - Get Your Way SRL

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ A complete example can be found [here](example/example.dart)
 
 ## Drawings
 
+Here is a list of the different elements that can be shown on the screen. For more information on parameters and authorized values, feel free to look at the code documentation for more advanced details.
+
 ### 1. BlankScreen
 
 Fills the screen with a solid color. If no color is given, the screen will be filled with the last color used, useful for erasing parts of the screen.
@@ -130,8 +132,6 @@ final drawing = TextDrawing(
   maxLines: 2,
 );
 ```
-
-Look at the documentation for details about each parameter.
 
 ### 3. IconDrawing
 

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -8,7 +8,7 @@ library flutter_gyw;
 export 'src/bt_device.dart' show GYWBtDevice;
 export 'src/bt_manager.dart' show GYWBtManager;
 export 'src/drawings.dart'
-    show BlankScreen, GYWDrawing, IconDrawing, TextDrawing;
+    show BlankScreen, GYWDrawing, IconDrawing, TextDrawing, RectangleDrawing;
 export 'src/exceptions.dart' show GYWException, GYWStatusException;
 export 'src/fonts.dart' show GYWFont;
 export 'src/icons.dart' show GYWIcon;

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -41,7 +41,10 @@ enum GYWControlCode {
   autoRotateScreen(0x0A),
 
   /// Enable or disable the display backlight
-  enableBacklight(0x0B);
+  enableBacklight(0x0B),
+
+  /// Draw a colored rectangle
+  drawRectangle(0x0C);
 
   /// The Control code value used internally on the device
   final int value;

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -66,7 +66,7 @@ class TextDrawing extends GYWDrawing {
   /// If no font is given, it uses the most recent one
   final GYWFont? font;
 
-  /// The size of the text (max 48 pt)
+  /// The text size. Overrides the font size.
   final int? size;
 
   /// The color of the text (in 8-characters ORGB format)

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -38,6 +38,8 @@ abstract class GYWDrawing {
         return BlankScreen.fromJson(data);
       case IconDrawing.type:
         return IconDrawing.fromJson(data);
+      case RectangleDrawing.type:
+        return RectangleDrawing.fromJson(data);
       default:
         throw UnsupportedError("Type '${data['type']}' is not supported.");
     }
@@ -509,6 +511,95 @@ class IconDrawing extends GYWDrawing {
       "data": iconFilename,
       "color": color,
       "scale": scale,
+    };
+  }
+}
+
+@immutable
+class RectangleDrawing extends GYWDrawing {
+  /// The type of the [RectangleDrawing].
+  static const String type = "rectangle";
+
+  /// The rectangle width.
+  final int width;
+
+  /// The rectangle height.
+  final int height;
+
+  /// The fill color. If null, the rectangle will use the current background color.
+  final String? color;
+
+  const RectangleDrawing({
+    required super.left,
+    required super.top,
+    required this.width,
+    required this.height,
+    this.color,
+  });
+
+  @override
+  List<GYWBtCommand> toCommands() {
+    final controlBytes = BytesBuilder()
+      ..add(int8Bytes(GYWControlCode.drawRectangle.value))
+      ..add(uint16Bytes(left))
+      ..add(uint16Bytes(top))
+      ..add(uint16Bytes(width))
+      ..add(uint16Bytes(height))
+      ..add(rgba8888BytesFromColorString(color));
+
+    return [
+      GYWBtCommand(
+        GYWCharacteristic.ctrlDisplay,
+        controlBytes.toBytes(),
+      ),
+    ];
+  }
+
+  @override
+  String toString() {
+    return 'RectangleDrawing{left: $left, top: $top, width: $width, height: $height, color: $color}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RectangleDrawing &&
+          runtimeType == other.runtimeType &&
+          left == other.left &&
+          top == other.top &&
+          width == other.width &&
+          height == other.height &&
+          color == other.color;
+
+  @override
+  int get hashCode => Object.hash(
+        left,
+        top,
+        width,
+        height,
+        color,
+      );
+
+  /// Deserializes a [RectangleDrawing] from JSON data
+  factory RectangleDrawing.fromJson(Map<String, dynamic> data) {
+    return RectangleDrawing(
+      left: data["left"] as int,
+      top: data["top"] as int,
+      width: data["width"] as int,
+      height: data["height"] as int,
+      color: data["color"] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      "type": type,
+      "left": left,
+      "top": top,
+      "width": width,
+      "height": height,
+      "color": color,
     };
   }
 }

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -9,10 +9,30 @@ Uint8List int32Bytes(
 
 /// Converts a int8 into bytes
 Uint8List int8Bytes(
+  int value,
+) =>
+    Uint8List(1)..buffer.asByteData().setInt8(0, value);
+
+/// Converts a uint16 into bytes
+Uint8List uint16Bytes(
   int value, {
   Endian endian = Endian.little,
 }) =>
-    Uint8List(1)..buffer.asByteData().setInt8(0, value);
+    Uint8List(2)..buffer.asByteData().setUint16(0, value, endian);
+
+/// Converts an ARGB color string to an RGBA8888 bytes array
+Uint8List rgba8888BytesFromColorString(String? color) {
+  if (color == null) {
+    return Uint8List(4);
+  }
+
+  final int alpha = int.parse(color.substring(0, 2), radix: 16);
+  final int red = int.parse(color.substring(2, 4), radix: 16);
+  final int green = int.parse(color.substring(4, 6), radix: 16);
+  final int blue = int.parse(color.substring(6, 8), radix: 16);
+
+  return Uint8List.fromList([red, green, blue, alpha]);
+}
 
 /// Allows to compare Comparable object using inequality signs
 extension Compare<T> on Comparable<T> {


### PR DESCRIPTION
The new drawing is `RectangleDrawing` which allows for drawing colored rectangles. If the color is null, the rectangle will use the current background color which can be used to partially clear the screen.

A list with a short description of every drawing that can be sent has been added to the documentation.