### PR TITLE
Fix blank.svg not rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.4
 
 * [FIX] Make icon scale deserialization work also with integers, not only doubles
+* [FIX] Fix blank.svg not rendering
 
 ## 1.1.3
 * [DEL] Deprecate delays when sending commands and set their default value to 0

--- a/assets/icons/blank.svg
+++ b/assets/icons/blank.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 0 100 100" width="48"><rect width="100%" height="100%" /></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48" height="48" version="1.1" viewBox="0 -960 960 960" xmlns="http://www.w3.org/2000/svg">
+ <rect y="-960" width="960" height="960"/>
+</svg>


### PR DESCRIPTION
blank.svg was not rendering at all in Flutter and was completely transparent before this fix.