### PR TITLE
Fix bluetooth not enabled error when it's actually enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [FIX] Make icon scale deserialization work also with integers, not only doubles
 * [ADD] Add a new drawing for colored rectangles which allows for partially clearing the screen
 * [FIX] Fix blank.svg not rendering
+* [FIX] Fix bluetooth not enabled error when it's actually enabled
 
 ## 1.1.3
 * [DEL] Deprecate delays when sending commands and set their default value to 0

--- a/lib/src/bt_manager.dart
+++ b/lib/src/bt_manager.dart
@@ -13,8 +13,6 @@ class GYWBtManager {
   }
 
   Future<void> _init() async {
-    bluetoothOn = await bluetoothOnAsync;
-
     FlutterBluePlus.adapterState.listen((state) {
       if (bluetoothOn != (state == BluetoothAdapterState.on)) {
         bluetoothOn = state == BluetoothAdapterState.on;
@@ -36,15 +34,6 @@ class GYWBtManager {
 
   /// A function triggered when there is a Bluetooth status change
   void Function(bool)? onBluetoothStatusChange;
-
-  /// Manually refreshes the Bluetooth status and returns the new status
-  Future<bool> get bluetoothOnAsync async {
-    final BluetoothAdapterState bluetoothState =
-        await FlutterBluePlus.adapterState.first;
-    bluetoothOn = bluetoothState == BluetoothAdapterState.on;
-
-    return bluetoothOn;
-  }
 
   void _addDevice(GYWBtDevice device) {
     final index = devices.indexWhere(


### PR DESCRIPTION
Don't manually query the state of bluetooth because the stream already returns the current value when first listened to.