### PR TITLE
Implement dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 1.1.4
+## 1.2.0
 
 * [FIX] Make icon scale deserialization work also with integers, not only doubles
 * [ADD] Add a new drawing for colored rectangles which allows for partially clearing the screen
 * [FIX] Fix blank.svg not rendering
 * [ADD] Add `SpinnerDrawing` for drawing animated spinners
 * [FIX] Fix bluetooth not enabled error when it's actually enabled
+* [ADD] Implement dark mode
 
 ## 1.1.3
 * [DEL] Deprecate delays when sending commands and set their default value to 0

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -7,7 +7,7 @@ library flutter_gyw;
 
 export 'src/bt_device.dart' show GYWBtDevice;
 export 'src/bt_manager.dart' show GYWBtManager;
-export 'src/color.dart' show Dark;
+export 'src/color.dart' show InvertLightness;
 export 'src/drawings.dart'
     show
         BlankScreen,

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -7,6 +7,7 @@ library flutter_gyw;
 
 export 'src/bt_device.dart' show GYWBtDevice;
 export 'src/bt_manager.dart' show GYWBtManager;
+export 'src/color.dart' show Dark;
 export 'src/drawings.dart'
     show
         BlankScreen,

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -22,6 +22,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   bool _isDisconnecting = false;
   bool _isConnected = false;
   bool _screenOn = false;
+  bool _darkMode = false;
 
   /// Whether the connection to the device is in progress
   bool get isConnecting => _isConnecting;
@@ -38,9 +39,17 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   ///
   /// By setting the lastRssi, the lastSeen value is also updated
   int get lastRssi => _lastRssi;
+
+  bool get darkMode => _darkMode;
+
   set lastRssi(int lastRssi) {
     _lastRssi = lastRssi;
     lastSeen = DateTime.now();
+    notifyListeners();
+  }
+
+  set darkMode(bool darkMode) {
+    _darkMode = darkMode;
     notifyListeners();
   }
 
@@ -179,7 +188,9 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     GYWDrawing drawing, {
     @Deprecated("Delay is no longer needed") int delay = 0,
   }) async {
-    final commands = drawing.toCommands();
+    final commands = drawing.toCommands(
+      darkMode: darkMode,
+    );
 
     for (final GYWBtCommand command in commands) {
       await _sendBTCommand(command);

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -22,7 +22,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   bool _isDisconnecting = false;
   bool _isConnected = false;
   bool _screenOn = false;
-  bool _darkMode = false;
 
   /// Whether the connection to the device is in progress
   bool get isConnecting => _isConnecting;
@@ -40,16 +39,9 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   /// By setting the lastRssi, the lastSeen value is also updated
   int get lastRssi => _lastRssi;
 
-  bool get darkMode => _darkMode;
-
   set lastRssi(int lastRssi) {
     _lastRssi = lastRssi;
     lastSeen = DateTime.now();
-    notifyListeners();
-  }
-
-  set darkMode(bool darkMode) {
-    _darkMode = darkMode;
     notifyListeners();
   }
 
@@ -188,9 +180,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     GYWDrawing drawing, {
     @Deprecated("Delay is no longer needed") int delay = 0,
   }) async {
-    final commands = drawing.toCommands(
-      darkMode: darkMode,
-    );
+    final commands = drawing.toCommands();
 
     for (final GYWBtCommand command in commands) {
       await _sendBTCommand(command);

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+extension Dark on Color {
+  Color dark() => _rotateColor(_invertColor(this));
+}
+
+Color _invertColor(Color color) {
+  return Color.fromARGB(
+    color.alpha,
+    255 - color.red,
+    255 - color.green,
+    255 - color.blue,
+  );
+}
+
+Color _rotateColor(Color color) {
+  final hsvColor = HSVColor.fromColor(color);
+  final rotatedColor = hsvColor.withHue((hsvColor.hue + 180.0) % 360.0);
+  return rotatedColor.toColor();
+}
+
+Color colorFromHex(String color) {
+  return Color.fromARGB(
+    int.parse(color.substring(0, 2), radix: 16),
+    int.parse(color.substring(2, 4), radix: 16),
+    int.parse(color.substring(4, 6), radix: 16),
+    int.parse(color.substring(6, 8), radix: 16),
+  );
+}
+
+String hexFromColor(Color color) {
+  return "${color.alpha.toRadixString(16).padLeft(2, "0")}"
+      "${color.red.toRadixString(16).padLeft(2, "0")}"
+      "${color.green.toRadixString(16).padLeft(2, "0")}"
+      "${color.blue.toRadixString(16).padLeft(2, "0")}";
+}

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -2,8 +2,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
-extension Dark on Color {
-  Color dark() {
+extension InvertLightness on Color {
+  Color invertLightness() {
     final hslColor = HSLColor.fromColor(this);
     return hslColor.withLightness(1.0 - hslColor.lightness).toColor();
   }

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -3,22 +3,10 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 
 extension Dark on Color {
-  Color dark() => _rotateColor(_invertColor(this));
-}
-
-Color _invertColor(Color color) {
-  return Color.fromARGB(
-    color.alpha,
-    255 - color.red,
-    255 - color.green,
-    255 - color.blue,
-  );
-}
-
-Color _rotateColor(Color color) {
-  final hsvColor = HSVColor.fromColor(color);
-  final rotatedColor = hsvColor.withHue((hsvColor.hue + 180.0) % 360.0);
-  return rotatedColor.toColor();
+  Color dark() {
+    final hslColor = HSLColor.fromColor(this);
+    return hslColor.withLightness(1.0 - hslColor.lightness).toColor();
+  }
 }
 
 Color colorFromHex(String color) {

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 
 extension Dark on Color {
@@ -33,4 +35,14 @@ String hexFromColor(Color color) {
       "${color.red.toRadixString(16).padLeft(2, "0")}"
       "${color.green.toRadixString(16).padLeft(2, "0")}"
       "${color.blue.toRadixString(16).padLeft(2, "0")}";
+}
+
+/// Converts a color to an RGBA8888 bytes array
+Uint8List rgba8888BytesFromColor(Color color) {
+  return Uint8List.fromList([
+    color.red,
+    color.green,
+    color.blue,
+    color.alpha,
+  ]);
 }

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -167,7 +167,7 @@ class TextDrawing extends GYWDrawing {
 
     Color c = colorFromHex(color ?? "FF000000");
     if (darkMode) {
-      c = c.dark();
+      c = c.invertLightness();
     }
     final String hexColor = hexFromColor(c);
     final String shortColor =
@@ -333,7 +333,7 @@ class BlankScreen extends GYWDrawing {
       // Add color value
       Color c = colorFromHex(color!);
       if (darkMode) {
-        c = c.dark();
+        c = c.invertLightness();
       }
 
       controlBytes.add(utf8.encode(hexFromColor(c)));
@@ -436,7 +436,7 @@ class IconDrawing extends GYWDrawing {
 
     Color c = colorFromHex(color ?? "FF000000");
     if (darkMode) {
-      c = c.dark();
+      c = c.invertLightness();
     }
     final String hexColor = hexFromColor(c);
     controlBytes.add(utf8.encode(hexColor));
@@ -555,7 +555,7 @@ class RectangleDrawing extends GYWDrawing {
     if (color != null) {
       c = colorFromHex(color!);
       if (darkMode) {
-        c = c.dark();
+        c = c.invertLightness();
       }
     }
 
@@ -658,7 +658,7 @@ class SpinnerDrawing extends GYWDrawing {
     if (color != null) {
       c = colorFromHex(color!);
       if (darkMode) {
-        c = c.dark();
+        c = c.invertLightness();
       }
     }
 

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -108,7 +108,7 @@ class TextDrawing extends GYWDrawing {
 
     int currentTop = top;
     for (final String line in _wrapText()) {
-      commands.addAll(_lineToCommands(line, currentTop));
+      commands.addAll(_lineToCommands(line, currentTop, darkMode));
       currentTop += charHeight;
     }
     return commands;
@@ -154,7 +154,7 @@ class TextDrawing extends GYWDrawing {
     yield line.toString();
   }
 
-  List<GYWBtCommand> _lineToCommands(String line, int top) {
+  List<GYWBtCommand> _lineToCommands(String line, int top, bool darkMode) {
     // Bytes generation for the control data (command code + params)
     final controlBytes = BytesBuilder();
 
@@ -167,7 +167,12 @@ class TextDrawing extends GYWDrawing {
 
     String shortColor = "NULL";
     if (color != null) {
-      shortColor = color![0] + color![2] + color![4] + color![6];
+      Color c = colorFromHex(color!);
+      if (darkMode) {
+        c = c.dark();
+      }
+      final String hexColor = hexFromColor(c);
+      shortColor = hexColor[0] + hexColor[2] + hexColor[4] + hexColor[6];
     }
     controlBytes.add(utf8.encode(shortColor));
 

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -100,7 +100,7 @@ class TextDrawing extends GYWDrawing {
 
   @override
   GYWDrawing invertLightness() {
-    final String color = this.color ?? "FFFFFFFF";
+    final String color = this.color ?? "FF000000";
 
     return TextDrawing(
       text: text,
@@ -453,7 +453,7 @@ class IconDrawing extends GYWDrawing {
 
   @override
   GYWDrawing invertLightness() {
-    final String color = this.color ?? "FFFFFFFF";
+    final String color = this.color ?? "FF000000";
     return IconDrawing._(
       top: top,
       left: left,

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -165,15 +165,13 @@ class TextDrawing extends GYWDrawing {
     controlBytes.add(utf8.encode(font?.prefix ?? "NUL"));
     controlBytes.add(int8Bytes(size ?? 0));
 
-    String shortColor = "NULL";
-    if (color != null) {
-      Color c = colorFromHex(color!);
-      if (darkMode) {
-        c = c.dark();
-      }
-      final String hexColor = hexFromColor(c);
-      shortColor = hexColor[0] + hexColor[2] + hexColor[4] + hexColor[6];
+    Color c = colorFromHex(color ?? "FF000000");
+    if (darkMode) {
+      c = c.dark();
     }
+    final String hexColor = hexFromColor(c);
+    final String shortColor =
+        hexColor[0] + hexColor[2] + hexColor[4] + hexColor[6];
     controlBytes.add(utf8.encode(shortColor));
 
     return [
@@ -436,14 +434,11 @@ class IconDrawing extends GYWDrawing {
     controlBytes.add(int32Bytes(left));
     controlBytes.add(int32Bytes(top));
 
-    String hexColor = "NULLNULL";
-    if (color != null) {
-      Color c = colorFromHex(color!);
-      if (darkMode) {
-        c = c.dark();
-      }
-      hexColor = hexFromColor(c);
+    Color c = colorFromHex(color ?? "FF000000");
+    if (darkMode) {
+      c = c.dark();
     }
+    final String hexColor = hexFromColor(c);
     controlBytes.add(utf8.encode(hexColor));
     controlBytes.add(byteFromScale(scale));
 

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -27,16 +27,6 @@ Uint8List uint16Bytes(
 }) =>
     Uint8List(2)..buffer.asByteData().setUint16(0, value, endian);
 
-/// Converts a color to an RGBA8888 bytes array
-Uint8List rgba8888BytesFromColor(Color color) {
-  return Uint8List.fromList([
-    color.red,
-    color.green,
-    color.blue,
-    color.alpha,
-  ]);
-}
-
 /// Allows to compare Comparable object using inequality signs
 extension Compare<T> on Comparable<T> {
   bool operator >(T other) => compareTo(other) > 0;

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'dart:ui';
 
 /// Converts a int32 into bytes
 Uint8List int32Bytes(
@@ -26,18 +27,14 @@ Uint8List uint16Bytes(
 }) =>
     Uint8List(2)..buffer.asByteData().setUint16(0, value, endian);
 
-/// Converts an ARGB color string to an RGBA8888 bytes array
-Uint8List rgba8888BytesFromColorString(String? color) {
-  if (color == null) {
-    return Uint8List(4);
-  }
-
-  final int alpha = int.parse(color.substring(0, 2), radix: 16);
-  final int red = int.parse(color.substring(2, 4), radix: 16);
-  final int green = int.parse(color.substring(4, 6), radix: 16);
-  final int blue = int.parse(color.substring(6, 8), radix: 16);
-
-  return Uint8List.fromList([red, green, blue, alpha]);
+/// Converts a color to an RGBA8888 bytes array
+Uint8List rgba8888BytesFromColor(Color color) {
+  return Uint8List.fromList([
+    color.red,
+    color.green,
+    color.blue,
+    color.alpha,
+  ]);
 }
 
 /// Allows to compare Comparable object using inequality signs

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -1,5 +1,4 @@
 import 'dart:typed_data';
-import 'dart:ui';
 
 /// Converts a int32 into bytes
 Uint8List int32Bytes(


### PR DESCRIPTION
There is a `darkMode` boolean in GYWBtDevice that will transform all colors on the fly when commands are sent through Bluetooth.

Users of this library can use the method Color.dark() to get colors appropriate for dark mode.

Color conversion is done by keeping the hue and inverting the lightness.