### PR TITLE
Fix broken API

### DIFF
--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -682,9 +682,8 @@ SpinnerDrawing{
       top: data["top"] as int,
       scale: data["scale"] as num,
       color: data["color"] as String?,
-      animationTimingFunction: AnimationTimingFunction.values.firstWhere(
-        (element) =>
-            element.name == data["animation_timing_function"] as String,
+      animationTimingFunction: AnimationTimingFunction.values.byName(
+        data["animation_timing_function"] as String,
       ),
       spinsPerSecond: data["spins_per_second"] as num,
     );
@@ -705,12 +704,11 @@ SpinnerDrawing{
 }
 
 enum AnimationTimingFunction {
-  linear(0, "linear"),
-  ease_in(1, "ease-in"),
-  ease_out(2, "ease-out");
+  linear(0),
+  ease_in(1),
+  ease_out(2);
 
   final int id;
-  final String name;
 
-  const AnimationTimingFunction(this.id, this.name);
+  const AnimationTimingFunction(this.id);
 }


### PR DESCRIPTION
I broke the API compared to master. When deserializing `AnimationTimingFunction`, it incorrectly tries to read "ease-in" instead of "ease_in" for example .

This PR reverts the changes made to `AnimationTimingFunction`. I removed the `AnimationTimingFunction.name` field because it shadows another field with the same name defined by Dart.