### PR TITLE
Change field types from num to double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.1
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization
+* [IMP] Change field types from num to double
 
 ## 1.2.0
 * [FIX] Make icon scale deserialization work also with integers, not only doubles

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -597,7 +597,7 @@ class SpinnerDrawing extends GYWDrawing {
   static const String type = "spinner";
 
   /// The scale of the image.
-  final num scale;
+  final double scale;
 
   /// The fill color. If null, the image colors will be preserved.
   final String? color;
@@ -606,15 +606,15 @@ class SpinnerDrawing extends GYWDrawing {
   final AnimationTimingFunction animationTimingFunction;
 
   /// How many rotations per second.
-  final num spinsPerSecond;
+  final double spinsPerSecond;
 
   const SpinnerDrawing({
     required super.left,
     required super.top,
-    this.scale = 1,
+    this.scale = 1.0,
     this.color,
     this.animationTimingFunction = AnimationTimingFunction.linear,
-    this.spinsPerSecond = 1,
+    this.spinsPerSecond = 1.0,
   });
 
   @override
@@ -680,12 +680,12 @@ SpinnerDrawing{
     return SpinnerDrawing(
       left: data["left"] as int,
       top: data["top"] as int,
-      scale: data["scale"] as num,
+      scale: (data["scale"] as num).toDouble(),
       color: data["color"] as String?,
       animationTimingFunction: AnimationTimingFunction.values.byName(
         data["animation_timing_function"] as String,
       ),
-      spinsPerSecond: data["spins_per_second"] as num,
+      spinsPerSecond: (data["spins_per_second"] as num).toDouble(),
     );
   }
 

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -51,7 +51,7 @@ extension Compare<T> on Comparable<T> {
   bool operator <=(T other) => compareTo(other) <= 0;
 }
 
-List<int> byteFromScale(num scale) {
+List<int> byteFromScale(double scale) {
   scale = scale.clamp(0.01, 13.7);
   int scaleByte;
   if (scale >= 1.0) {


### PR DESCRIPTION
For simplicity, all fields that were previously of type `num` are now of type `double`.