### PR TITLE
Convert legacy WhiteScreen into BlankScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization
 * [IMP] Change field types from num to double
+* [IMP] Convert legacy WhiteScreen into BlankScreen
 
 ## 1.2.0
 * [FIX] Make icon scale deserialization work also with integers, not only doubles

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -33,7 +33,7 @@ abstract class GYWDrawing {
       case TextDrawing.type:
         return TextDrawing.fromJson(data);
       case WhiteScreen.type:
-        return WhiteScreen.fromJson(data);
+        return const BlankScreen(color: "FFFFFFFF");
       case BlankScreen.type:
         return BlankScreen.fromJson(data);
       case IconDrawing.type:


### PR DESCRIPTION
WhiteScreen is no longer exported, so instead of returning an instance of WhiteScreen that API users cannot check for, it is now automatically converted into a BlankScreen on deserialization.