### PR TITLE
Fix custom icon filenames not constructed properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.2.1
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization
 * [IMP] Change field types from num to double
 * [IMP] Convert legacy WhiteScreen into BlankScreen
+* [FIX] Fix custom icon filenames not constructed properly
 
 ## 1.2.0
 * [FIX] Make icon scale deserialization work also with integers, not only doubles

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -519,8 +519,8 @@ class RectangleDrawing extends GYWDrawing {
   final String? color;
 
   const RectangleDrawing({
-    required super.left,
-    required super.top,
+    super.left = 0,
+    super.top = 0,
     required this.width,
     required this.height,
     this.color,
@@ -611,8 +611,8 @@ class SpinnerDrawing extends GYWDrawing {
   final double spinsPerSecond;
 
   const SpinnerDrawing({
-    required super.left,
-    required super.top,
+    super.left,
+    super.top,
     this.scale = 1.0,
     this.color,
     this.animationTimingFunction = AnimationTimingFunction.linear,

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -519,8 +519,8 @@ class RectangleDrawing extends GYWDrawing {
   final String? color;
 
   const RectangleDrawing({
-    super.left = 0,
-    super.top = 0,
+    super.left,
+    super.top,
     required this.width,
     required this.height,
     this.color,

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -422,7 +422,9 @@ class IconDrawing extends GYWDrawing {
     return <GYWBtCommand>[
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
-        const Utf8Encoder().convert("$iconFilename.bin"),
+        const Utf8Encoder().convert(
+          isCustom ? iconFilename : "$iconFilename.svg",
+        ),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,


### PR DESCRIPTION
Before this fix, custom icons couldn't have an extension because the library automatically appended `.bin` at the end.

Now, the filename of a custom icon is preserved and sent as is to the firmware.