### PR TITLE
Fix position encoding for rectangles and spinners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.1
+* [FIX] Fix position encoding for rectangles and spinners
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization
 * [IMP] Change field types from num to double

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -530,8 +530,8 @@ class RectangleDrawing extends GYWDrawing {
   List<GYWBtCommand> toCommands() {
     final controlBytes = BytesBuilder()
       ..add(int8Bytes(GYWControlCode.drawRectangle.value))
-      ..add(uint16Bytes(left))
-      ..add(uint16Bytes(top))
+      ..add(int32Bytes(left))
+      ..add(int32Bytes(top))
       ..add(uint16Bytes(width))
       ..add(uint16Bytes(height))
       ..add(rgba8888BytesFromColorString(color));
@@ -623,8 +623,8 @@ class SpinnerDrawing extends GYWDrawing {
   List<GYWBtCommand> toCommands() {
     final controlBytes = BytesBuilder()
       ..add(int8Bytes(GYWControlCode.displaySpinner.value))
-      ..add(uint16Bytes(left))
-      ..add(uint16Bytes(top))
+      ..add(int32Bytes(left))
+      ..add(int32Bytes(top))
       ..add(rgba8888BytesFromColorString(color))
       ..add(byteFromScale(scale))
       ..add(uint8Bytes(animationTimingFunction.id))

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -156,8 +156,8 @@ class TextDrawing extends GYWDrawing {
     final controlBytes = BytesBuilder();
 
     controlBytes.add(int8Bytes(GYWControlCode.displayText.value));
-    controlBytes.add(int32Bytes(left));
-    controlBytes.add(int32Bytes(top));
+    controlBytes.add(uint32Bytes(left));
+    controlBytes.add(uint32Bytes(top));
 
     controlBytes.add(utf8.encode(font?.prefix ?? "NUL"));
     controlBytes.add(int8Bytes(size ?? 0));
@@ -414,8 +414,8 @@ class IconDrawing extends GYWDrawing {
   List<GYWBtCommand> toCommands() {
     final controlBytes = BytesBuilder();
     controlBytes.add(int8Bytes(GYWControlCode.displayImage.value));
-    controlBytes.add(int32Bytes(left));
-    controlBytes.add(int32Bytes(top));
+    controlBytes.add(uint32Bytes(left));
+    controlBytes.add(uint32Bytes(top));
     controlBytes.add(utf8.encode(hexFromColor(color)));
     controlBytes.add(byteFromScale(scale));
 
@@ -530,8 +530,8 @@ class RectangleDrawing extends GYWDrawing {
   List<GYWBtCommand> toCommands() {
     final controlBytes = BytesBuilder()
       ..add(int8Bytes(GYWControlCode.drawRectangle.value))
-      ..add(int32Bytes(left))
-      ..add(int32Bytes(top))
+      ..add(uint32Bytes(left))
+      ..add(uint32Bytes(top))
       ..add(uint16Bytes(width))
       ..add(uint16Bytes(height))
       ..add(rgba8888BytesFromColor(color));
@@ -623,8 +623,8 @@ class SpinnerDrawing extends GYWDrawing {
   List<GYWBtCommand> toCommands() {
     final controlBytes = BytesBuilder()
       ..add(int8Bytes(GYWControlCode.displaySpinner.value))
-      ..add(int32Bytes(left))
-      ..add(int32Bytes(top))
+      ..add(uint32Bytes(left))
+      ..add(uint32Bytes(top))
       ..add(rgba8888BytesFromColor(color))
       ..add(byteFromScale(scale))
       ..add(uint8Bytes(animationTimingFunction.id))


### PR DESCRIPTION
Rectangles and Spinners were positioned with two integers (`left`, `top`) that were encoded with 2 bytes each. This was not consistent with the position of other drawing elements, where these two integers were encoded on 4 bytes.