### PR TITLE
Fix 4-byte color strings not converted correctly into commands

### DIFF
--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -162,7 +162,7 @@ class TextDrawing extends GYWDrawing {
     controlBytes.add(utf8.encode(font?.prefix ?? "NUL"));
     controlBytes.add(int8Bytes(size ?? 0));
 
-    final shortColor = [color.red, color.green, color.blue, color.alpha]
+    final shortColor = [color.alpha, color.red, color.green, color.blue]
         .map((channel) => (channel ~/ 16).toRadixString(16))
         .join();
 


### PR DESCRIPTION
Apparently I didn't properly test #51 and I inverted the red and alpha channel. It should be ARGB, not RGBA.