### PR TITLE
Remove deprecated functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+* [DEL] Remove deprecated functionality
+
 ## 1.2.1
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,7 +23,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
     # - always_specify_types # only public types must be specified (type_annotate_public_apis)
     # - always_use_package_imports # we do this commonly
     - annotate_overrides
@@ -52,8 +51,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives
     - avoid_setters_without_getters

--- a/example/example.dart
+++ b/example/example.dart
@@ -36,7 +36,7 @@ class _GYWExampleScreenState extends State<GYWExampleScreen> {
     ];
 
     for (final GYWDrawing drawing in drawings) {
-      await connectedDevice?.displayDrawing(drawing);
+      await connectedDevice?.sendDrawing(drawing);
     }
   }
 

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:developer';
 import 'dart:typed_data';
 
@@ -38,6 +37,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   ///
   /// By setting the lastRssi, the lastSeen value is also updated
   int get lastRssi => _lastRssi;
+
   set lastRssi(int lastRssi) {
     _lastRssi = lastRssi;
     lastSeen = DateTime.now();
@@ -175,68 +175,18 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   }
 
   /// Sends data to the aRdent device to display a [GYWDrawing]
-  Future<void> sendDrawing(
-    GYWDrawing drawing, {
-    @Deprecated("Delay is no longer needed") int delay = 0,
-  }) async {
+  Future<void> sendDrawing(GYWDrawing drawing) async {
     final commands = drawing.toCommands();
 
     for (final GYWBtCommand command in commands) {
       await _sendBTCommand(command);
-      if (delay != 0) {
-        await Future<void>.delayed(Duration(milliseconds: delay));
-      }
-    }
-  }
-
-  /// Sends data to the aRdent device to display a [GYWDrawing]
-  @Deprecated("This method is going to be replaced by sendDrawing")
-  Future<void> displayDrawing(
-    GYWDrawing drawing, {
-    @Deprecated("Delay is no longer needed") int delay = 0,
-  }) async {
-    final commands = drawing.toCommands();
-
-    for (final GYWBtCommand command in commands) {
-      await _sendBTCommand(command);
-      if (delay != 0) {
-        await Future<void>.delayed(Duration(milliseconds: delay));
-      }
-    }
-  }
-
-  /// Sets the default font on the aRdent to display the next [TextDrawing]
-  @Deprecated("Set the font when drawing text with `TextDrawing`")
-  Future<void> setFont(
-    GYWFont font, {
-    @Deprecated("Delay is no longer needed") int delay = 0,
-  }) async {
-    final commands = <GYWBtCommand>[
-      GYWBtCommand(
-        GYWCharacteristic.nameDisplay,
-        const Utf8Encoder().convert(font.prefix),
-      ),
-      GYWBtCommand(
-        GYWCharacteristic.ctrlDisplay,
-        int8Bytes(GYWControlCode.setFont.value),
-      ),
-    ];
-
-    for (final GYWBtCommand command in commands) {
-      await _sendBTCommand(command);
-      if (delay != 0) {
-        await Future<void>.delayed(Duration(milliseconds: delay));
-      }
     }
   }
 
   /// Sets the screen brightness.
   ///
   /// The value must be between 0 and 1.
-  Future<void> setBrightness(
-    double value, {
-    @Deprecated("Delay is no longer needed") int delay = 0,
-  }) async {
+  Future<void> setBrightness(double value) async {
     assert(value >= 0 && value <= 1);
 
     final controlBytes = BytesBuilder()
@@ -249,18 +199,12 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     );
 
     await _sendBTCommand(command);
-    if (delay != 0) {
-      await Future<void>.delayed(Duration(milliseconds: delay));
-    }
   }
 
   /// Sets the screen contrast.
   ///
   /// The value must be between 0 and 1.
-  Future<void> setContrast(
-    double value, {
-    @Deprecated("Delay is no longer needed") int delay = 0,
-  }) async {
+  Future<void> setContrast(double value) async {
     assert(value >= 0 && value <= 1);
 
     final controlBytes = BytesBuilder()
@@ -273,9 +217,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     );
 
     await _sendBTCommand(command);
-    if (delay != 0) {
-      await Future<void>.delayed(Duration(milliseconds: delay));
-    }
   }
 
   /// Enables or disables the screen autorotation.
@@ -331,9 +272,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   /// Turns the screen on and initializes it for future drawings.
   ///
   /// This method must be called once before performing display operations.
-  Future<void> startDisplay({
-    @Deprecated("Delay is no longer needed") int delay = 0,
-  }) async {
+  Future<void> startDisplay() async {
     if (_screenOn) {
       // Skip the command
       return;
@@ -345,9 +284,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     );
 
     await _sendBTCommand(command);
-    if (delay != 0) {
-      await Future<void>.delayed(Duration(milliseconds: delay));
-    }
 
     _screenOn = true;
   }

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -32,8 +32,6 @@ abstract class GYWDrawing {
     switch (data["type"]) {
       case TextDrawing.type:
         return TextDrawing.fromJson(data);
-      case WhiteScreen.type:
-        return const BlankScreen(color: Colors.white);
       case BlankScreen.type:
         return BlankScreen.fromJson(data);
       case IconDrawing.type:
@@ -255,54 +253,6 @@ class TextDrawing extends GYWDrawing {
   }
 }
 
-/// A drawing to reset the screen of the aRdent device to a white screen
-@Deprecated(
-  "WhiteScreen has been replaced by BlankScreen "
-  "who has a variable background color",
-)
-class WhiteScreen extends GYWDrawing {
-  /// The type of the [WhiteScreen] drawing
-  static const String type = "white_screen";
-
-  @Deprecated(
-    "WhiteScreen has been replaced by BlankScreen "
-    "who has a variable background color",
-  )
-  const WhiteScreen();
-
-  @override
-  List<GYWBtCommand> toCommands() {
-    return [
-      GYWBtCommand(
-        GYWCharacteristic.ctrlDisplay,
-        int8Bytes(GYWControlCode.clear.value),
-      ),
-    ];
-  }
-
-  @override
-  String toString() {
-    return "Drawing: white screen";
-  }
-
-  /// Deserializes a [WhiteScreen] from JSON data
-  @Deprecated(
-    "WhiteScreen has been replaced by BlankScreen "
-    "who has a variable background color",
-  )
-  // ignore: avoid_unused_constructor_parameters
-  factory WhiteScreen.fromJson(Map<String, dynamic> data) {
-    return const WhiteScreen();
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return {
-      "type": type,
-    };
-  }
-}
-
 /// A drawing to reset the content of the screen and its background color
 @immutable
 class BlankScreen extends GYWDrawing {
@@ -463,7 +413,7 @@ class IconDrawing extends GYWDrawing {
   /// Deserializes an [IconDrawing] from JSON data
   factory IconDrawing.fromJson(Map<String, dynamic> data) {
     // Deprecated "icon" key will be deprecated in future versions
-    final String icon = data["data"] as String? ?? data["icon"] as String;
+    final String icon = data["data"] as String;
 
     final GYWIcon? gywIcon = GYWIcon.values.cast<GYWIcon?>().firstWhere(
           (element) => element!.filename == icon || element.name == icon,
@@ -495,8 +445,6 @@ class IconDrawing extends GYWDrawing {
       "type": type,
       "left": left,
       "top": top,
-      // Deprecated: "icon" key will be deprecated in future versions
-      "icon": icon?.name ?? customIconFilename,
       "data": iconFilename,
       "color": hexFromColor(color),
       "scale": scale,

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -65,10 +65,6 @@ enum GYWIcon {
     this.height,
   );
 
-  /// The path of the associated file in the assets folder
-  @Deprecated("Use pathPng instead")
-  String get path => "assets/icons/$filename.png";
-
   /// The path of the associated PNG file in the assets folder
   String get pathPng => "assets/icons/$filename.png";
 

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -112,7 +112,13 @@ void main() {
         }
 
         expect(
-          File("$assetFolderPath/${icon.path}").existsSync(),
+          File("$assetFolderPath/${icon.pathPng}").existsSync(),
+          isTrue,
+          reason: "File of $icon is missing",
+        );
+
+        expect(
+          File("$assetFolderPath/${icon.pathSvg}").existsSync(),
           isTrue,
           reason: "File of $icon is missing",
         );


### PR DESCRIPTION
Removed:
- `GYWBtDevice.displayDrawing` which was replaced with `GYWBtDevice.sendDrawing`.
- The `WhiteScreen` class.
- Command delays.
- `GYWIcon.path`. Use `GYWIcon.pathPng` or `GYWIcon.pathSvg` instead.