### PR TITLE
Convert GYWIcon and GYWFont from enums to classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+* [REFACTOR] Convert GYWIcon and GYWFont from enums to classes
+
 ## 1.2.1
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,8 +2,6 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gyw/flutter_gyw.dart';
-import 'package:flutter_gyw/src/fonts.dart';
-import 'package:flutter_gyw/src/icons.dart';
 
 class GYWExampleScreen extends StatefulWidget {
   const GYWExampleScreen({super.key});

--- a/example/example.dart
+++ b/example/example.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_gyw/flutter_gyw.dart';
 import 'package:flutter_gyw/src/fonts.dart';
+import 'package:flutter_gyw/src/icons.dart';
 
 class GYWExampleScreen extends StatefulWidget {
   const GYWExampleScreen({super.key});
@@ -27,7 +28,7 @@ class _GYWExampleScreenState extends State<GYWExampleScreen> {
   Future<void> _sendExampleData() async {
     final List<GYWDrawing> drawings = <GYWDrawing>[
       const BlankScreen(color: Colors.white),
-      const IconDrawing(GYWIcon.up, top: 50, left: 60),
+      IconDrawing(GYWIcons.up.icon, top: 50, left: 60),
       TextDrawing(
         text: "Hello world",
         top: 50,

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gyw/flutter_gyw.dart';
+import 'package:flutter_gyw/src/fonts.dart';
 
 class GYWExampleScreen extends StatefulWidget {
   const GYWExampleScreen({super.key});
@@ -24,14 +25,14 @@ class _GYWExampleScreenState extends State<GYWExampleScreen> {
   }
 
   Future<void> _sendExampleData() async {
-    const List<GYWDrawing> drawings = <GYWDrawing>[
-      BlankScreen(color: Colors.white),
-      IconDrawing(GYWIcon.up, top: 50, left: 60),
+    final List<GYWDrawing> drawings = <GYWDrawing>[
+      const BlankScreen(color: Colors.white),
+      const IconDrawing(GYWIcon.up, top: 50, left: 60),
       TextDrawing(
         text: "Hello world",
         top: 50,
         left: 220,
-        font: GYWFont.medium,
+        font: GYWFonts.medium.font,
       ),
     ];
 

--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -17,6 +17,6 @@ export 'src/drawings.dart'
         SpinnerDrawing,
         AnimationTimingFunction;
 export 'src/exceptions.dart' show GYWException, GYWStatusException;
-export 'src/fonts.dart' show GYWFont;
-export 'src/icons.dart' show GYWIcon;
+export 'src/fonts.dart' show GYWFont, GYWFonts;
+export 'src/icons.dart' show GYWIcon, GYWIcons;
 export 'src/screen.dart' show GYWScreenParameters;

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -217,9 +217,11 @@ class TextDrawing extends GYWDrawing {
   factory TextDrawing.fromJson(Map<String, dynamic> data) {
     GYWFont? font;
     try {
-      font = GYWFonts.values.firstWhere(
-        (e) => e.font.name == data["font"],
-      ).font;
+      font = GYWFonts.values
+          .firstWhere(
+            (e) => e.font.name == data["font"],
+          )
+          .font;
     } on StateError {
       font = null;
     }
@@ -465,10 +467,14 @@ class IconDrawing extends GYWDrawing {
     // Deprecated "icon" key will be deprecated in future versions
     final String icon = data["data"] as String? ?? data["icon"] as String;
 
-    final GYWIcon? gywIcon = GYWIcon.values.cast<GYWIcon?>().firstWhere(
-          (element) => element!.filename == icon || element.name == icon,
+    final GYWIcon? gywIcon = GYWIcons.values
+        .cast<GYWIcons?>()
+        .firstWhere(
+          (element) =>
+              element!.icon.filename == icon || element.icon.name == icon,
           orElse: () => null,
-        );
+        )
+        ?.icon;
 
     if (gywIcon != null) {
       return IconDrawing(

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -98,7 +98,7 @@ class TextDrawing extends GYWDrawing {
 
   @override
   List<GYWBtCommand> toCommands() {
-    final int fontSize = size ?? font?.size ?? GYWFont.small.size;
+    final int fontSize = size ?? font?.size ?? GYWFonts.small.font.size;
     final int charHeight = (fontSize * 1.33).ceil();
 
     final List<GYWBtCommand> commands = [];
@@ -127,7 +127,7 @@ class TextDrawing extends GYWDrawing {
       textWidth = maxWidth;
     }
 
-    final int fontSize = size ?? font?.size ?? GYWFont.small.size;
+    final int fontSize = size ?? font?.size ?? GYWFonts.small.font.size;
     final int charWidth = (fontSize * 0.6).ceil();
     final int maxCharsPerLine = textWidth ~/ charWidth;
 
@@ -217,9 +217,9 @@ class TextDrawing extends GYWDrawing {
   factory TextDrawing.fromJson(Map<String, dynamic> data) {
     GYWFont? font;
     try {
-      font = GYWFont.values.firstWhere(
-        (e) => e.index == data["font"] || e.name == data["font"],
-      );
+      font = GYWFonts.values.firstWhere(
+        (e) => e.font.name == data["font"],
+      ).font;
     } on StateError {
       font = null;
     }
@@ -246,7 +246,7 @@ class TextDrawing extends GYWDrawing {
       "data": text,
       // Deprecated: "text" key will be deprecated in future version
       "text": text,
-      if (font != null) "font": font!.index,
+      if (font != null) "font": font!.prefix,
       "size": size,
       "color": hexFromColor(color),
       "max_width": maxWidth,

--- a/lib/src/fonts.dart
+++ b/lib/src/fonts.dart
@@ -1,10 +1,5 @@
 /// The text fonts supported on aRdent smart glasses
-enum GYWFont {
-  small("Small", "a10", 18, 10, 25),
-  medium("Medium", "b14", 24, 14, 33, true),
-  large("Large", "a16", 28, 16, 39),
-  huge("Huge", "b28", 48, 28, 67, true);
-
+class GYWFont {
   /// The name of the font
   final String name;
 
@@ -23,12 +18,23 @@ enum GYWFont {
   /// Whether the fontweight is bold (w700) or normal (w400)
   final bool bold;
 
-  const GYWFont(
-    this.name,
-    this.prefix, [
-    this.size = 12,
-    this.width = 12,
-    this.height = 20,
-    this.bold = false,
-  ]);
+  const GYWFont({
+    required this.name,
+    required this.prefix,
+    required this.size,
+    required this.width,
+    required this.height,
+    required this.bold,
+  });
+}
+
+enum GYWFonts {
+  small(GYWFont(name: "Small", prefix: "a10", size: 18, width: 10, height: 25, bold: false)),
+  medium(GYWFont(name: "Medium", prefix: "b14", size: 24, width: 14, height: 33, bold: true)),
+  large(GYWFont(name: "Large", prefix: "a16", size: 28, width: 16, height: 39, bold: false)),
+  huge(GYWFont(name: "Huge", prefix: "b28", size: 48, width: 28, height: 67, bold: true));
+
+  final GYWFont font;
+
+  const GYWFonts(this.font);
 }

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -1,51 +1,4 @@
-/// The icons supported by aRdent smart glasses
-enum GYWIcon {
-  blank("Blank", "blank", 48, 48),
-  build("Build", "build", 48, 48),
-  camera("Camera", "camera", 48, 48),
-  chat("Chat", "chat", 48, 48),
-  checkbox("Checkbox checked", "check", 48, 48),
-  checkboxEmpty("Checkbox empty", "uncheck", 48, 48),
-  cloud_backup("Cloud backup", "cloud_backup", 48, 48),
-  cloud_done("Cloud done", "cloud_done", 48, 48),
-  done("Done", "done", 48, 48),
-  down("Down", "down", 48, 48),
-  edit("Edit", "edit", 48, 48),
-  file("File", "file", 48, 48),
-  folder("Folder", "folder", 48, 48),
-  gyw("GYW", "GYW", 121, 48),
-  help("Help", "help", 48, 48),
-  info("Information", "info", 48, 48),
-  left("Left", "left", 48, 48),
-  location("Location", "location", 48, 48),
-  next("Next", "next", 48, 48),
-  nfc("NFC", "nfc", 48, 48),
-  person("Person", "person", 48, 48),
-  previous("Previous", "prev", 48, 48),
-  rename("Rename", "rename", 48, 48),
-  right("Right", "right", 48, 48),
-  settings("Settings", "settings", 48, 48),
-  up("Up", "up", 48, 48),
-  warning("Warning", "warning", 48, 48),
-  wifi("Wi-Fi", "wifi", 48, 48),
-  wifi_off("Wi-Fi off", "wifi_off", 48, 48),
-  key_0("Key 0", "key_0", 48, 48),
-  key_1("Key 1", "key_1", 48, 48),
-  key_2("Key 2", "key_2", 48, 48),
-  key_3("Key 3", "key_3", 48, 48),
-  key_4("Key 4", "key_4", 48, 48),
-  key_5("Key 5", "key_5", 48, 48),
-  key_6("Key 6", "key_6", 48, 48),
-  key_7("Key 7", "key_7", 48, 48),
-  key_8("Key 8", "key_8", 48, 48),
-  key_9("Key 9", "key_9", 48, 48),
-  key_A("Key A", "key_A", 48, 48),
-  key_B("Key B", "key_B", 48, 48),
-  key_C("Key C", "key_C", 48, 48),
-  key_D("Key D", "key_D", 48, 48),
-  key_star("Key *", "key_star", 48, 48),
-  key_num("Key #", "key_#", 48, 48);
-
+class GYWIcon {
   /// The name of the icon
   final String name;
 
@@ -58,12 +11,12 @@ enum GYWIcon {
   /// The height (in pixels) of the icon
   final double height;
 
-  const GYWIcon(
-    this.name,
-    this.filename,
-    this.width,
-    this.height,
-  );
+  const GYWIcon({
+    required this.name,
+    required this.filename,
+    required this.width,
+    required this.height,
+  });
 
   /// The path of the associated file in the assets folder
   @Deprecated("Use pathPng instead")
@@ -74,4 +27,372 @@ enum GYWIcon {
 
   /// The path of the associated SVG file in the assets folder
   String get pathSvg => "assets/icons/$filename.svg";
+}
+
+/// The icons supported by aRdent smart glasses
+enum GYWIcons {
+  blank(
+    GYWIcon(
+      name: "Blank",
+      filename: "blank",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  build(
+    GYWIcon(
+      name: "Build",
+      filename: "build",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  camera(
+    GYWIcon(
+      name: "Camera",
+      filename: "camera",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  chat(
+    GYWIcon(
+      name: "Chat",
+      filename: "chat",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  checkbox(
+    GYWIcon(
+      name: "Checkbox checked",
+      filename: "check",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  checkboxEmpty(
+    GYWIcon(
+      name: "Checkbox empty",
+      filename: "uncheck",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  cloud_backup(
+    GYWIcon(
+      name: "Cloud backup",
+      filename: "cloud_backup",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  cloud_done(
+    GYWIcon(
+      name: "Cloud done",
+      filename: "cloud_done",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  done(
+    GYWIcon(
+      name: "Done",
+      filename: "done",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  down(
+    GYWIcon(
+      name: "Down",
+      filename: "down",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  edit(
+    GYWIcon(
+      name: "Edit",
+      filename: "edit",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  file(
+    GYWIcon(
+      name: "File",
+      filename: "file",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  folder(
+    GYWIcon(
+      name: "Folder",
+      filename: "folder",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  gyw(
+    GYWIcon(
+      name: "GYW",
+      filename: "GYW",
+      width: 121,
+      height: 48,
+    ),
+  ),
+  help(
+    GYWIcon(
+      name: "Help",
+      filename: "help",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  info(
+    GYWIcon(
+      name: "Information",
+      filename: "info",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  left(
+    GYWIcon(
+      name: "Left",
+      filename: "left",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  location(
+    GYWIcon(
+      name: "Location",
+      filename: "location",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  next(
+    GYWIcon(
+      name: "Next",
+      filename: "next",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  nfc(
+    GYWIcon(
+      name: "NFC",
+      filename: "nfc",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  person(
+    GYWIcon(
+      name: "Person",
+      filename: "person",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  previous(
+    GYWIcon(
+      name: "Previous",
+      filename: "prev",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  rename(
+    GYWIcon(
+      name: "Rename",
+      filename: "rename",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  right(
+    GYWIcon(
+      name: "Right",
+      filename: "right",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  settings(
+    GYWIcon(
+      name: "Settings",
+      filename: "settings",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  up(
+    GYWIcon(
+      name: "Up",
+      filename: "up",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  warning(
+    GYWIcon(
+      name: "Warning",
+      filename: "warning",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  wifi(
+    GYWIcon(
+      name: "Wi-Fi",
+      filename: "wifi",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  wifi_off(
+    GYWIcon(
+      name: "Wi-Fi off",
+      filename: "wifi_off",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_0(
+    GYWIcon(
+      name: "Key 0",
+      filename: "key_0",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_1(
+    GYWIcon(
+      name: "Key 1",
+      filename: "key_1",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_2(
+    GYWIcon(
+      name: "Key 2",
+      filename: "key_2",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_3(
+    GYWIcon(
+      name: "Key 3",
+      filename: "key_3",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_4(
+    GYWIcon(
+      name: "Key 4",
+      filename: "key_4",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_5(
+    GYWIcon(
+      name: "Key 5",
+      filename: "key_5",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_6(
+    GYWIcon(
+      name: "Key 6",
+      filename: "key_6",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_7(
+    GYWIcon(
+      name: "Key 7",
+      filename: "key_7",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_8(
+    GYWIcon(
+      name: "Key 8",
+      filename: "key_8",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_9(
+    GYWIcon(
+      name: "Key 9",
+      filename: "key_9",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_A(
+    GYWIcon(
+      name: "Key A",
+      filename: "key_A",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_B(
+    GYWIcon(
+      name: "Key B",
+      filename: "key_B",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_C(
+    GYWIcon(
+      name: "Key C",
+      filename: "key_C",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_D(
+    GYWIcon(
+      name: "Key D",
+      filename: "key_D",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_star(
+    GYWIcon(
+      name: "Key *",
+      filename: "key_star",
+      width: 48,
+      height: 48,
+    ),
+  ),
+  key_num(
+    GYWIcon(
+      name: "Key #",
+      filename: "key_#",
+      width: 48,
+      height: 48,
+    ),
+  );
+
+  final GYWIcon icon;
+
+  const GYWIcons(this.icon);
 }

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gyw/flutter_gyw.dart';
+import 'package:flutter_gyw/src/fonts.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -35,9 +36,9 @@ void main() {
     });
 
     test('Text with font', () {
-      const GYWFont font = GYWFont.medium;
+      final GYWFont font = GYWFonts.medium.font;
 
-      const GYWDrawing drawing = TextDrawing(
+      final GYWDrawing drawing = TextDrawing(
         text: "Text with font",
         font: font,
       );
@@ -46,9 +47,9 @@ void main() {
     });
 
     test('Text with font and position', () {
-      const font = GYWFont.medium;
+      final font = GYWFonts.medium.font;
 
-      const GYWDrawing drawing = TextDrawing(
+      final GYWDrawing drawing = TextDrawing(
         text: "Text with font and position",
         left: 150,
         top: 250,

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -2,8 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gyw/flutter_gyw.dart';
-import 'package:flutter_gyw/src/fonts.dart';
-import 'package:flutter_gyw/src/icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gyw/flutter_gyw.dart';
 import 'package:flutter_gyw/src/fonts.dart';
+import 'package:flutter_gyw/src/icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -60,17 +61,17 @@ void main() {
     });
 
     test('Icon', () {
-      const GYWIcon icon = GYWIcon.checkbox;
+      final GYWIcon icon = GYWIcons.checkbox.icon;
 
-      const GYWDrawing drawing = IconDrawing(icon);
+      final GYWDrawing drawing = IconDrawing(icon);
 
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
     test('Icon with position', () {
-      const GYWIcon icon = GYWIcon.up;
+      final GYWIcon icon = GYWIcons.up.icon;
 
-      const GYWDrawing drawing = IconDrawing(
+      final GYWDrawing drawing = IconDrawing(
         icon,
         left: 120,
         top: 220,
@@ -80,9 +81,9 @@ void main() {
     });
 
     test('Icon with color', () {
-      const GYWIcon icon = GYWIcon.left;
+      final GYWIcon icon = GYWIcons.left.icon;
 
-      const GYWDrawing drawing = IconDrawing(
+      final GYWDrawing drawing = IconDrawing(
         icon,
         left: 120,
         top: 220,
@@ -106,14 +107,20 @@ void main() {
     test('All icons', () {
       final assetFolderPath = Platform.environment['UNIT_TEST_ASSETS'];
 
-      for (final GYWIcon icon in GYWIcon.values) {
-        if (icon == GYWIcon.key_num) {
+      for (final GYWIcons icon in GYWIcons.values) {
+        if (icon == GYWIcons.key_num) {
           // # symbol is not managed correctly
           continue;
         }
 
         expect(
-          File("$assetFolderPath/${icon.path}").existsSync(),
+          File("$assetFolderPath/${icon.icon.pathPng}").existsSync(),
+          isTrue,
+          reason: "File of $icon is missing",
+        );
+
+        expect(
+          File("$assetFolderPath/${icon.icon.pathSvg}").existsSync(),
           isTrue,
           reason: "File of $icon is missing",
         );


### PR DESCRIPTION
Add support for custom icons and fonts. Enums cannot hold non-constant values, so `GYWIcon` and `GYWFont` are converted into classes, and enums `GYWIcons` and `GYWFonts` contain instances of icons and fonts supported by the device by default.