### PR TITLE
Encode all colors in RGBA8888 when sending them to the glasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+[REFACTOR] Encode all colors in RGBA8888 when sending them to the glasses
+
 ## 1.2.1
 * [ADD] Add spinner image
 * [FIX] Fix incorrect spinner serialization

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -162,11 +162,7 @@ class TextDrawing extends GYWDrawing {
     controlBytes.add(utf8.encode(font?.prefix ?? "NUL"));
     controlBytes.add(int8Bytes(size ?? 0));
 
-    final shortColor = [color.alpha, color.red, color.green, color.blue]
-        .map((channel) => (channel ~/ 16).toRadixString(16))
-        .join();
-
-    controlBytes.add(utf8.encode(shortColor));
+    controlBytes.add(rgba8888BytesFromColor(color));
 
     return [
       GYWBtCommand(
@@ -321,7 +317,7 @@ class BlankScreen extends GYWDrawing {
 
     if (color != null) {
       // Add color value
-      controlBytes.add(utf8.encode(hexFromColor(color!)));
+      controlBytes.add(rgba8888BytesFromColor(color));
     }
 
     return [
@@ -416,7 +412,7 @@ class IconDrawing extends GYWDrawing {
     controlBytes.add(int8Bytes(GYWControlCode.displayImage.value));
     controlBytes.add(int32Bytes(left));
     controlBytes.add(int32Bytes(top));
-    controlBytes.add(utf8.encode(hexFromColor(color)));
+    controlBytes.add(rgba8888BytesFromColor(color));
     controlBytes.add(byteFromScale(scale));
 
     return <GYWBtCommand>[


### PR DESCRIPTION
Most colors were previously encoded as 8 or 4 hex characters. They are are now all encoded as RGBA8888.