### PR TITLE
Update UUIDs of BLE characteristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * [DEL] Remove deprecated functionality
 * [REFACTOR] Encode positions as int16 instead of int32
 * [REFACTOR] Convert GYWIcon and GYWFont from enums to classes
+* [REFACTOR] Update UUIDs of BLE characteristics
 
 ## 1.2.1
 * [ADD] Add spinner image

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -3,10 +3,10 @@ import 'package:flutter/services.dart';
 /// A class gathering the characteristics used on aRdent
 enum GYWCharacteristic {
   /// Characterisitic to control the display
-  ctrlDisplay("00004c31-0000-1000-8000-00805f9b34fb"),
+  ctrlDisplay("9f3443f3-5149-4d53-9b92-35def7b82e52"),
 
   /// Characteristic to give data to the display
-  nameDisplay("00004c32-0000-1000-8000-00805f9b34fb");
+  nameDisplay("9f3443f3-5149-4d53-9b92-35def7b82e53");
 
   /// The UUID of the characteristic
   final String uuid;


### PR DESCRIPTION
Some UUIDs have changed because they were reserved by the Bluetooth SIG which we shouldn't have used.