### PR TITLE
Make maxLines nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [REFACTOR] Convert BlankScreen class into the clearScreen method
 * [IMP] Update lint lists and improve documentation
 * [REFACTOR] Update UUIDs of BLE characteristics
+* [REFACTOR] Make maxLines nullable
 
 ## 1.2.1
 * [ADD] Add spinner image

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -115,7 +115,9 @@ class TextDrawing extends GYWDrawing {
     final int? maxWidth =
         this.maxWidth != null && this.maxWidth! < 1 ? null : this.maxWidth;
 
-    final int? maxLines = this.maxLines != null ? max(1, this.maxLines!) : null;
+    final int? maxLines = this.maxLines != null && this.maxLines! < 1
+        ? max(1, this.maxLines!)
+        : null;
 
     int textWidth;
     final int availableWidth = GYWScreenParameters.width - left;

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -74,13 +74,14 @@ class TextDrawing extends GYWDrawing {
   /// The maximum width (in pixels) of the text.
   ///
   /// It will be wrapped on multiple lines if it is too long.
+  /// Null disables the limit.
   final int? maxWidth;
 
   /// The maximum number of lines the text can be wrapped on.
   ///
   /// All extra lines will be ignored.
-  /// The value 0 is special and disables the limit.
-  final int maxLines;
+  /// Null disables the limit.
+  final int? maxLines;
 
   /// Creates a text element.
   const TextDrawing({
@@ -114,7 +115,7 @@ class TextDrawing extends GYWDrawing {
     final int? maxWidth =
         this.maxWidth != null && this.maxWidth! < 1 ? null : this.maxWidth;
 
-    final int maxLines = max(0, this.maxLines);
+    final int? maxLines = this.maxLines != null ? max(1, this.maxLines!) : null;
 
     int textWidth;
     final int availableWidth = GYWScreenParameters.width - left;
@@ -137,7 +138,7 @@ class TextDrawing extends GYWDrawing {
       if (line.isNotEmpty && line.length + 1 + word.length > maxCharsPerLine) {
         yield line.toString();
         lines++;
-        if (maxLines != 0 && lines >= maxLines) {
+        if (maxLines != null && lines >= maxLines) {
           return;
         }
         line.clear();


### PR DESCRIPTION
Disable the max lines limit when the attribute is null, which makes it consistent with maxWidth.