### PR TITLE
Put all drawings under a Freezed union

### DIFF
--- a/lib/flutter_gyw.dart
+++ b/lib/flutter_gyw.dart
@@ -12,9 +12,13 @@ export "src/drawings.dart"
         AnimationTimingFunction,
         GYWDrawing,
         IconDrawing,
+        IconDrawingExtension,
         RectangleDrawing,
+        RectangleDrawingExtension,
         SpinnerDrawing,
-        TextDrawing;
+        SpinnerDrawingExtension,
+        TextDrawing,
+        TextDrawingExtension;
 export "src/exceptions.dart" show GYWException, GYWStatusException;
 export "src/fonts.dart" show GYWFont, GYWFonts;
 export "src/icons.dart" show GYWIcon, GYWIcons;

--- a/lib/src/drawings.freezed.dart
+++ b/lib/src/drawings.freezed.dart
@@ -14,63 +14,160 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
+GYWDrawing _$GYWDrawingFromJson(Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'TextDrawing':
+      return TextDrawing.fromJson(json);
+    case 'IconDrawing':
+      return IconDrawing.fromJson(json);
+    case 'RectangleDrawing':
+      return RectangleDrawing.fromJson(json);
+    case 'SpinnerDrawing':
+      return SpinnerDrawing.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'runtimeType', 'GYWDrawing',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
 /// @nodoc
-mixin _$TextDrawing {
+mixin _$GYWDrawing {
+  /// The distance (in pixels) from the top of the screen
   int get top => throw _privateConstructorUsedError;
+
+  /// The distance (in pixels) from the left side of the screen
   int get left => throw _privateConstructorUsedError;
 
-  /// The text that must be displayed
-  String get text => throw _privateConstructorUsedError;
-
-  /// The [GYWFont] to use
-  ///
-  /// If no font is given, it uses the most recent one
-  GYWFont? get font => throw _privateConstructorUsedError;
-
-  /// The text size. Overrides the font size.
-  int? get size => throw _privateConstructorUsedError;
-
   /// The color of the text.
-  int get colorHex => throw _privateConstructorUsedError;
-
-  /// The maximum width (in pixels) of the text.
-  ///
-  /// It will be wrapped on multiple lines if it is too long.
-  /// Null disables the limit.
-  int? get maxWidth => throw _privateConstructorUsedError;
-
-  /// The maximum number of lines the text can be wrapped on.
-  ///
-  /// All extra lines will be ignored.
-  /// Null disables the limit.
-  int? get maxLines => throw _privateConstructorUsedError;
-
+  int? get colorHex => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)
+        textDrawing,
+    required TResult Function(int top, int left,
+            @GYWIconJsonConverter() GYWIcon icon, int colorHex, double scale)
+        iconDrawing,
+    required TResult Function(
+            int top, int left, int width, int height, int? colorHex)
+        rectangleDrawing,
+    required TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)
+        spinnerDrawing,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult? Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult? Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult? Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TextDrawing value) textDrawing,
+    required TResult Function(IconDrawing value) iconDrawing,
+    required TResult Function(RectangleDrawing value) rectangleDrawing,
+    required TResult Function(SpinnerDrawing value) spinnerDrawing,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TextDrawing value)? textDrawing,
+    TResult? Function(IconDrawing value)? iconDrawing,
+    TResult? Function(RectangleDrawing value)? rectangleDrawing,
+    TResult? Function(SpinnerDrawing value)? spinnerDrawing,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TextDrawing value)? textDrawing,
+    TResult Function(IconDrawing value)? iconDrawing,
+    TResult Function(RectangleDrawing value)? rectangleDrawing,
+    TResult Function(SpinnerDrawing value)? spinnerDrawing,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $TextDrawingCopyWith<TextDrawing> get copyWith =>
+  $GYWDrawingCopyWith<GYWDrawing> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $TextDrawingCopyWith<$Res> {
-  factory $TextDrawingCopyWith(
-          TextDrawing value, $Res Function(TextDrawing) then) =
-      _$TextDrawingCopyWithImpl<$Res, TextDrawing>;
+abstract class $GYWDrawingCopyWith<$Res> {
+  factory $GYWDrawingCopyWith(
+          GYWDrawing value, $Res Function(GYWDrawing) then) =
+      _$GYWDrawingCopyWithImpl<$Res, GYWDrawing>;
   @useResult
-  $Res call(
-      {int top,
-      int left,
-      String text,
-      GYWFont? font,
-      int? size,
-      int colorHex,
-      int? maxWidth,
-      int? maxLines});
+  $Res call({int top, int left, int colorHex});
 }
 
 /// @nodoc
-class _$TextDrawingCopyWithImpl<$Res, $Val extends TextDrawing>
-    implements $TextDrawingCopyWith<$Res> {
-  _$TextDrawingCopyWithImpl(this._value, this._then);
+class _$GYWDrawingCopyWithImpl<$Res, $Val extends GYWDrawing>
+    implements $GYWDrawingCopyWith<$Res> {
+  _$GYWDrawingCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
@@ -82,12 +179,7 @@ class _$TextDrawingCopyWithImpl<$Res, $Val extends TextDrawing>
   $Res call({
     Object? top = null,
     Object? left = null,
-    Object? text = null,
-    Object? font = freezed,
-    Object? size = freezed,
     Object? colorHex = null,
-    Object? maxWidth = freezed,
-    Object? maxLines = freezed,
   }) {
     return _then(_value.copyWith(
       top: null == top
@@ -98,37 +190,17 @@ class _$TextDrawingCopyWithImpl<$Res, $Val extends TextDrawing>
           ? _value.left
           : left // ignore: cast_nullable_to_non_nullable
               as int,
-      text: null == text
-          ? _value.text
-          : text // ignore: cast_nullable_to_non_nullable
-              as String,
-      font: freezed == font
-          ? _value.font
-          : font // ignore: cast_nullable_to_non_nullable
-              as GYWFont?,
-      size: freezed == size
-          ? _value.size
-          : size // ignore: cast_nullable_to_non_nullable
-              as int?,
       colorHex: null == colorHex
-          ? _value.colorHex
+          ? _value.colorHex!
           : colorHex // ignore: cast_nullable_to_non_nullable
               as int,
-      maxWidth: freezed == maxWidth
-          ? _value.maxWidth
-          : maxWidth // ignore: cast_nullable_to_non_nullable
-              as int?,
-      maxLines: freezed == maxLines
-          ? _value.maxLines
-          : maxLines // ignore: cast_nullable_to_non_nullable
-              as int?,
     ) as $Val);
   }
 }
 
 /// @nodoc
 abstract class _$$TextDrawingImplCopyWith<$Res>
-    implements $TextDrawingCopyWith<$Res> {
+    implements $GYWDrawingCopyWith<$Res> {
   factory _$$TextDrawingImplCopyWith(
           _$TextDrawingImpl value, $Res Function(_$TextDrawingImpl) then) =
       __$$TextDrawingImplCopyWithImpl<$Res>;
@@ -138,7 +210,7 @@ abstract class _$$TextDrawingImplCopyWith<$Res>
       {int top,
       int left,
       String text,
-      GYWFont? font,
+      @GYWFontJsonConverter() GYWFont? font,
       int? size,
       int colorHex,
       int? maxWidth,
@@ -147,7 +219,7 @@ abstract class _$$TextDrawingImplCopyWith<$Res>
 
 /// @nodoc
 class __$$TextDrawingImplCopyWithImpl<$Res>
-    extends _$TextDrawingCopyWithImpl<$Res, _$TextDrawingImpl>
+    extends _$GYWDrawingCopyWithImpl<$Res, _$TextDrawingImpl>
     implements _$$TextDrawingImplCopyWith<$Res> {
   __$$TextDrawingImplCopyWithImpl(
       _$TextDrawingImpl _value, $Res Function(_$TextDrawingImpl) _then)
@@ -203,22 +275,30 @@ class __$$TextDrawingImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
-class _$TextDrawingImpl extends _TextDrawing {
+@JsonSerializable()
+class _$TextDrawingImpl extends TextDrawing {
   const _$TextDrawingImpl(
       {this.top = 0,
       this.left = 0,
       required this.text,
-      this.font,
+      @GYWFontJsonConverter() this.font,
       this.size,
       this.colorHex = 0xFF000000,
       this.maxWidth,
-      this.maxLines})
-      : super._();
+      this.maxLines,
+      final String? $type})
+      : $type = $type ?? 'TextDrawing',
+        super._();
 
+  factory _$TextDrawingImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TextDrawingImplFromJson(json);
+
+  /// The distance (in pixels) from the top of the screen
   @override
   @JsonKey()
   final int top;
+
+  /// The distance (in pixels) from the left side of the screen
   @override
   @JsonKey()
   final int left;
@@ -231,6 +311,7 @@ class _$TextDrawingImpl extends _TextDrawing {
   ///
   /// If no font is given, it uses the most recent one
   @override
+  @GYWFontJsonConverter()
   final GYWFont? font;
 
   /// The text size. Overrides the font size.
@@ -256,9 +337,12 @@ class _$TextDrawingImpl extends _TextDrawing {
   @override
   final int? maxLines;
 
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
   @override
   String toString() {
-    return 'TextDrawing(top: $top, left: $left, text: $text, font: $font, size: $size, colorHex: $colorHex, maxWidth: $maxWidth, maxLines: $maxLines)';
+    return 'GYWDrawing.textDrawing(top: $top, left: $left, text: $text, font: $font, size: $size, colorHex: $colorHex, maxWidth: $maxWidth, maxLines: $maxLines)';
   }
 
   @override
@@ -279,6 +363,7 @@ class _$TextDrawingImpl extends _TextDrawing {
                 other.maxLines == maxLines));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, top, left, text, font, size, colorHex, maxWidth, maxLines);
@@ -288,35 +373,182 @@ class _$TextDrawingImpl extends _TextDrawing {
   @pragma('vm:prefer-inline')
   _$$TextDrawingImplCopyWith<_$TextDrawingImpl> get copyWith =>
       __$$TextDrawingImplCopyWithImpl<_$TextDrawingImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)
+        textDrawing,
+    required TResult Function(int top, int left,
+            @GYWIconJsonConverter() GYWIcon icon, int colorHex, double scale)
+        iconDrawing,
+    required TResult Function(
+            int top, int left, int width, int height, int? colorHex)
+        rectangleDrawing,
+    required TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)
+        spinnerDrawing,
+  }) {
+    return textDrawing(
+        top, left, text, font, size, colorHex, maxWidth, maxLines);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult? Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult? Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult? Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+  }) {
+    return textDrawing?.call(
+        top, left, text, font, size, colorHex, maxWidth, maxLines);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (textDrawing != null) {
+      return textDrawing(
+          top, left, text, font, size, colorHex, maxWidth, maxLines);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TextDrawing value) textDrawing,
+    required TResult Function(IconDrawing value) iconDrawing,
+    required TResult Function(RectangleDrawing value) rectangleDrawing,
+    required TResult Function(SpinnerDrawing value) spinnerDrawing,
+  }) {
+    return textDrawing(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TextDrawing value)? textDrawing,
+    TResult? Function(IconDrawing value)? iconDrawing,
+    TResult? Function(RectangleDrawing value)? rectangleDrawing,
+    TResult? Function(SpinnerDrawing value)? spinnerDrawing,
+  }) {
+    return textDrawing?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TextDrawing value)? textDrawing,
+    TResult Function(IconDrawing value)? iconDrawing,
+    TResult Function(RectangleDrawing value)? rectangleDrawing,
+    TResult Function(SpinnerDrawing value)? spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (textDrawing != null) {
+      return textDrawing(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TextDrawingImplToJson(
+      this,
+    );
+  }
 }
 
-abstract class _TextDrawing extends TextDrawing {
-  const factory _TextDrawing(
+abstract class TextDrawing extends GYWDrawing {
+  const factory TextDrawing(
       {final int top,
       final int left,
       required final String text,
-      final GYWFont? font,
+      @GYWFontJsonConverter() final GYWFont? font,
       final int? size,
       final int colorHex,
       final int? maxWidth,
       final int? maxLines}) = _$TextDrawingImpl;
-  const _TextDrawing._() : super._();
+  const TextDrawing._() : super._();
+
+  factory TextDrawing.fromJson(Map<String, dynamic> json) =
+      _$TextDrawingImpl.fromJson;
 
   @override
+
+  /// The distance (in pixels) from the top of the screen
   int get top;
   @override
+
+  /// The distance (in pixels) from the left side of the screen
   int get left;
-  @override
 
   /// The text that must be displayed
   String get text;
-  @override
 
   /// The [GYWFont] to use
   ///
   /// If no font is given, it uses the most recent one
+  @GYWFontJsonConverter()
   GYWFont? get font;
-  @override
 
   /// The text size. Overrides the font size.
   int? get size;
@@ -324,14 +556,12 @@ abstract class _TextDrawing extends TextDrawing {
 
   /// The color of the text.
   int get colorHex;
-  @override
 
   /// The maximum width (in pixels) of the text.
   ///
   /// It will be wrapped on multiple lines if it is too long.
   /// Null disables the limit.
   int? get maxWidth;
-  @override
 
   /// The maximum number of lines the text can be wrapped on.
   ///
@@ -345,91 +575,24 @@ abstract class _TextDrawing extends TextDrawing {
 }
 
 /// @nodoc
-mixin _$IconDrawing {
-  int get top => throw _privateConstructorUsedError;
-  int get left => throw _privateConstructorUsedError;
-
-  /// The displayed [GYWIcon]
-  GYWIcon get icon => throw _privateConstructorUsedError;
-
-  /// Hexadecimal code of the icon fill color
-  int get colorHex => throw _privateConstructorUsedError;
-
-  /// The icon scaling factor.
-  double get scale => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $IconDrawingCopyWith<IconDrawing> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $IconDrawingCopyWith<$Res> {
-  factory $IconDrawingCopyWith(
-          IconDrawing value, $Res Function(IconDrawing) then) =
-      _$IconDrawingCopyWithImpl<$Res, IconDrawing>;
-  @useResult
-  $Res call({int top, int left, GYWIcon icon, int colorHex, double scale});
-}
-
-/// @nodoc
-class _$IconDrawingCopyWithImpl<$Res, $Val extends IconDrawing>
-    implements $IconDrawingCopyWith<$Res> {
-  _$IconDrawingCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? top = null,
-    Object? left = null,
-    Object? icon = null,
-    Object? colorHex = null,
-    Object? scale = null,
-  }) {
-    return _then(_value.copyWith(
-      top: null == top
-          ? _value.top
-          : top // ignore: cast_nullable_to_non_nullable
-              as int,
-      left: null == left
-          ? _value.left
-          : left // ignore: cast_nullable_to_non_nullable
-              as int,
-      icon: null == icon
-          ? _value.icon
-          : icon // ignore: cast_nullable_to_non_nullable
-              as GYWIcon,
-      colorHex: null == colorHex
-          ? _value.colorHex
-          : colorHex // ignore: cast_nullable_to_non_nullable
-              as int,
-      scale: null == scale
-          ? _value.scale
-          : scale // ignore: cast_nullable_to_non_nullable
-              as double,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
 abstract class _$$IconDrawingImplCopyWith<$Res>
-    implements $IconDrawingCopyWith<$Res> {
+    implements $GYWDrawingCopyWith<$Res> {
   factory _$$IconDrawingImplCopyWith(
           _$IconDrawingImpl value, $Res Function(_$IconDrawingImpl) then) =
       __$$IconDrawingImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int top, int left, GYWIcon icon, int colorHex, double scale});
+  $Res call(
+      {int top,
+      int left,
+      @GYWIconJsonConverter() GYWIcon icon,
+      int colorHex,
+      double scale});
 }
 
 /// @nodoc
 class __$$IconDrawingImplCopyWithImpl<$Res>
-    extends _$IconDrawingCopyWithImpl<$Res, _$IconDrawingImpl>
+    extends _$GYWDrawingCopyWithImpl<$Res, _$IconDrawingImpl>
     implements _$$IconDrawingImplCopyWith<$Res> {
   __$$IconDrawingImplCopyWithImpl(
       _$IconDrawingImpl _value, $Res Function(_$IconDrawingImpl) _then)
@@ -470,25 +633,34 @@ class __$$IconDrawingImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
-class _$IconDrawingImpl extends _IconDrawing {
+@JsonSerializable()
+class _$IconDrawingImpl extends IconDrawing {
   const _$IconDrawingImpl(
       {this.top = 0,
       this.left = 0,
-      required this.icon,
+      @GYWIconJsonConverter() required this.icon,
       this.colorHex = 0xFF000000,
-      this.scale = 1.0})
-      : super._();
+      this.scale = 1.0,
+      final String? $type})
+      : $type = $type ?? 'IconDrawing',
+        super._();
 
+  factory _$IconDrawingImpl.fromJson(Map<String, dynamic> json) =>
+      _$$IconDrawingImplFromJson(json);
+
+  /// The distance (in pixels) from the top of the screen
   @override
   @JsonKey()
   final int top;
+
+  /// The distance (in pixels) from the left side of the screen
   @override
   @JsonKey()
   final int left;
 
   /// The displayed [GYWIcon]
   @override
+  @GYWIconJsonConverter()
   final GYWIcon icon;
 
   /// Hexadecimal code of the icon fill color
@@ -501,9 +673,12 @@ class _$IconDrawingImpl extends _IconDrawing {
   @JsonKey()
   final double scale;
 
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
   @override
   String toString() {
-    return 'IconDrawing(top: $top, left: $left, icon: $icon, colorHex: $colorHex, scale: $scale)';
+    return 'GYWDrawing.iconDrawing(top: $top, left: $left, icon: $icon, colorHex: $colorHex, scale: $scale)';
   }
 
   @override
@@ -519,6 +694,7 @@ class _$IconDrawingImpl extends _IconDrawing {
             (identical(other.scale, scale) || other.scale == scale));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, top, left, icon, colorHex, scale);
@@ -528,30 +704,175 @@ class _$IconDrawingImpl extends _IconDrawing {
   @pragma('vm:prefer-inline')
   _$$IconDrawingImplCopyWith<_$IconDrawingImpl> get copyWith =>
       __$$IconDrawingImplCopyWithImpl<_$IconDrawingImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)
+        textDrawing,
+    required TResult Function(int top, int left,
+            @GYWIconJsonConverter() GYWIcon icon, int colorHex, double scale)
+        iconDrawing,
+    required TResult Function(
+            int top, int left, int width, int height, int? colorHex)
+        rectangleDrawing,
+    required TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)
+        spinnerDrawing,
+  }) {
+    return iconDrawing(top, left, icon, colorHex, scale);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult? Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult? Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult? Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+  }) {
+    return iconDrawing?.call(top, left, icon, colorHex, scale);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (iconDrawing != null) {
+      return iconDrawing(top, left, icon, colorHex, scale);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TextDrawing value) textDrawing,
+    required TResult Function(IconDrawing value) iconDrawing,
+    required TResult Function(RectangleDrawing value) rectangleDrawing,
+    required TResult Function(SpinnerDrawing value) spinnerDrawing,
+  }) {
+    return iconDrawing(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TextDrawing value)? textDrawing,
+    TResult? Function(IconDrawing value)? iconDrawing,
+    TResult? Function(RectangleDrawing value)? rectangleDrawing,
+    TResult? Function(SpinnerDrawing value)? spinnerDrawing,
+  }) {
+    return iconDrawing?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TextDrawing value)? textDrawing,
+    TResult Function(IconDrawing value)? iconDrawing,
+    TResult Function(RectangleDrawing value)? rectangleDrawing,
+    TResult Function(SpinnerDrawing value)? spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (iconDrawing != null) {
+      return iconDrawing(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$IconDrawingImplToJson(
+      this,
+    );
+  }
 }
 
-abstract class _IconDrawing extends IconDrawing {
-  const factory _IconDrawing(
+abstract class IconDrawing extends GYWDrawing {
+  const factory IconDrawing(
       {final int top,
       final int left,
-      required final GYWIcon icon,
+      @GYWIconJsonConverter() required final GYWIcon icon,
       final int colorHex,
       final double scale}) = _$IconDrawingImpl;
-  const _IconDrawing._() : super._();
+  const IconDrawing._() : super._();
+
+  factory IconDrawing.fromJson(Map<String, dynamic> json) =
+      _$IconDrawingImpl.fromJson;
 
   @override
+
+  /// The distance (in pixels) from the top of the screen
   int get top;
   @override
+
+  /// The distance (in pixels) from the left side of the screen
   int get left;
-  @override
 
   /// The displayed [GYWIcon]
+  @GYWIconJsonConverter()
   GYWIcon get icon;
   @override
 
   /// Hexadecimal code of the icon fill color
   int get colorHex;
-  @override
 
   /// The icon scaling factor.
   double get scale;
@@ -562,80 +883,8 @@ abstract class _IconDrawing extends IconDrawing {
 }
 
 /// @nodoc
-mixin _$RectangleDrawing {
-  int get top => throw _privateConstructorUsedError;
-  int get left => throw _privateConstructorUsedError;
-
-  /// The rectangle width.
-  int get width => throw _privateConstructorUsedError;
-
-  /// The rectangle height.
-  int get height => throw _privateConstructorUsedError;
-
-  /// The fill color. If null, the rectangle will use the current background color.
-  int? get colorHex => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $RectangleDrawingCopyWith<RectangleDrawing> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $RectangleDrawingCopyWith<$Res> {
-  factory $RectangleDrawingCopyWith(
-          RectangleDrawing value, $Res Function(RectangleDrawing) then) =
-      _$RectangleDrawingCopyWithImpl<$Res, RectangleDrawing>;
-  @useResult
-  $Res call({int top, int left, int width, int height, int? colorHex});
-}
-
-/// @nodoc
-class _$RectangleDrawingCopyWithImpl<$Res, $Val extends RectangleDrawing>
-    implements $RectangleDrawingCopyWith<$Res> {
-  _$RectangleDrawingCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? top = null,
-    Object? left = null,
-    Object? width = null,
-    Object? height = null,
-    Object? colorHex = freezed,
-  }) {
-    return _then(_value.copyWith(
-      top: null == top
-          ? _value.top
-          : top // ignore: cast_nullable_to_non_nullable
-              as int,
-      left: null == left
-          ? _value.left
-          : left // ignore: cast_nullable_to_non_nullable
-              as int,
-      width: null == width
-          ? _value.width
-          : width // ignore: cast_nullable_to_non_nullable
-              as int,
-      height: null == height
-          ? _value.height
-          : height // ignore: cast_nullable_to_non_nullable
-              as int,
-      colorHex: freezed == colorHex
-          ? _value.colorHex
-          : colorHex // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
 abstract class _$$RectangleDrawingImplCopyWith<$Res>
-    implements $RectangleDrawingCopyWith<$Res> {
+    implements $GYWDrawingCopyWith<$Res> {
   factory _$$RectangleDrawingImplCopyWith(_$RectangleDrawingImpl value,
           $Res Function(_$RectangleDrawingImpl) then) =
       __$$RectangleDrawingImplCopyWithImpl<$Res>;
@@ -646,7 +895,7 @@ abstract class _$$RectangleDrawingImplCopyWith<$Res>
 
 /// @nodoc
 class __$$RectangleDrawingImplCopyWithImpl<$Res>
-    extends _$RectangleDrawingCopyWithImpl<$Res, _$RectangleDrawingImpl>
+    extends _$GYWDrawingCopyWithImpl<$Res, _$RectangleDrawingImpl>
     implements _$$RectangleDrawingImplCopyWith<$Res> {
   __$$RectangleDrawingImplCopyWithImpl(_$RectangleDrawingImpl _value,
       $Res Function(_$RectangleDrawingImpl) _then)
@@ -687,19 +936,27 @@ class __$$RectangleDrawingImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
-class _$RectangleDrawingImpl extends _RectangleDrawing {
+@JsonSerializable()
+class _$RectangleDrawingImpl extends RectangleDrawing {
   const _$RectangleDrawingImpl(
       {this.top = 0,
       this.left = 0,
       required this.width,
       required this.height,
-      this.colorHex})
-      : super._();
+      this.colorHex,
+      final String? $type})
+      : $type = $type ?? 'RectangleDrawing',
+        super._();
 
+  factory _$RectangleDrawingImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RectangleDrawingImplFromJson(json);
+
+  /// The distance (in pixels) from the top of the screen
   @override
   @JsonKey()
   final int top;
+
+  /// The distance (in pixels) from the left side of the screen
   @override
   @JsonKey()
   final int left;
@@ -716,9 +973,12 @@ class _$RectangleDrawingImpl extends _RectangleDrawing {
   @override
   final int? colorHex;
 
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
   @override
   String toString() {
-    return 'RectangleDrawing(top: $top, left: $left, width: $width, height: $height, colorHex: $colorHex)';
+    return 'GYWDrawing.rectangleDrawing(top: $top, left: $left, width: $width, height: $height, colorHex: $colorHex)';
   }
 
   @override
@@ -734,6 +994,7 @@ class _$RectangleDrawingImpl extends _RectangleDrawing {
                 other.colorHex == colorHex));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, top, left, width, height, colorHex);
@@ -744,26 +1005,170 @@ class _$RectangleDrawingImpl extends _RectangleDrawing {
   _$$RectangleDrawingImplCopyWith<_$RectangleDrawingImpl> get copyWith =>
       __$$RectangleDrawingImplCopyWithImpl<_$RectangleDrawingImpl>(
           this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)
+        textDrawing,
+    required TResult Function(int top, int left,
+            @GYWIconJsonConverter() GYWIcon icon, int colorHex, double scale)
+        iconDrawing,
+    required TResult Function(
+            int top, int left, int width, int height, int? colorHex)
+        rectangleDrawing,
+    required TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)
+        spinnerDrawing,
+  }) {
+    return rectangleDrawing(top, left, width, height, colorHex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult? Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult? Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult? Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+  }) {
+    return rectangleDrawing?.call(top, left, width, height, colorHex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (rectangleDrawing != null) {
+      return rectangleDrawing(top, left, width, height, colorHex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TextDrawing value) textDrawing,
+    required TResult Function(IconDrawing value) iconDrawing,
+    required TResult Function(RectangleDrawing value) rectangleDrawing,
+    required TResult Function(SpinnerDrawing value) spinnerDrawing,
+  }) {
+    return rectangleDrawing(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TextDrawing value)? textDrawing,
+    TResult? Function(IconDrawing value)? iconDrawing,
+    TResult? Function(RectangleDrawing value)? rectangleDrawing,
+    TResult? Function(SpinnerDrawing value)? spinnerDrawing,
+  }) {
+    return rectangleDrawing?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TextDrawing value)? textDrawing,
+    TResult Function(IconDrawing value)? iconDrawing,
+    TResult Function(RectangleDrawing value)? rectangleDrawing,
+    TResult Function(SpinnerDrawing value)? spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (rectangleDrawing != null) {
+      return rectangleDrawing(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$RectangleDrawingImplToJson(
+      this,
+    );
+  }
 }
 
-abstract class _RectangleDrawing extends RectangleDrawing {
-  const factory _RectangleDrawing(
+abstract class RectangleDrawing extends GYWDrawing {
+  const factory RectangleDrawing(
       {final int top,
       final int left,
       required final int width,
       required final int height,
       final int? colorHex}) = _$RectangleDrawingImpl;
-  const _RectangleDrawing._() : super._();
+  const RectangleDrawing._() : super._();
+
+  factory RectangleDrawing.fromJson(Map<String, dynamic> json) =
+      _$RectangleDrawingImpl.fromJson;
 
   @override
+
+  /// The distance (in pixels) from the top of the screen
   int get top;
   @override
+
+  /// The distance (in pixels) from the left side of the screen
   int get left;
-  @override
 
   /// The rectangle width.
   int get width;
-  @override
 
   /// The rectangle height.
   int get height;
@@ -778,95 +1183,8 @@ abstract class _RectangleDrawing extends RectangleDrawing {
 }
 
 /// @nodoc
-mixin _$SpinnerDrawing {
-  int get top => throw _privateConstructorUsedError;
-  int get left => throw _privateConstructorUsedError;
-
-  /// The scale of the image.
-  double get scale => throw _privateConstructorUsedError;
-
-  /// The fill color. If null, the image colors will be preserved.
-  int? get colorHex => throw _privateConstructorUsedError;
-
-  /// The curve applied while spinning.
-  AnimationTimingFunction get animationTimingFunction =>
-      throw _privateConstructorUsedError;
-
-  /// How many rotations per second.
-  double get spinsPerSecond => throw _privateConstructorUsedError;
-
-  @JsonKey(ignore: true)
-  $SpinnerDrawingCopyWith<SpinnerDrawing> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $SpinnerDrawingCopyWith<$Res> {
-  factory $SpinnerDrawingCopyWith(
-          SpinnerDrawing value, $Res Function(SpinnerDrawing) then) =
-      _$SpinnerDrawingCopyWithImpl<$Res, SpinnerDrawing>;
-  @useResult
-  $Res call(
-      {int top,
-      int left,
-      double scale,
-      int? colorHex,
-      AnimationTimingFunction animationTimingFunction,
-      double spinsPerSecond});
-}
-
-/// @nodoc
-class _$SpinnerDrawingCopyWithImpl<$Res, $Val extends SpinnerDrawing>
-    implements $SpinnerDrawingCopyWith<$Res> {
-  _$SpinnerDrawingCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? top = null,
-    Object? left = null,
-    Object? scale = null,
-    Object? colorHex = freezed,
-    Object? animationTimingFunction = null,
-    Object? spinsPerSecond = null,
-  }) {
-    return _then(_value.copyWith(
-      top: null == top
-          ? _value.top
-          : top // ignore: cast_nullable_to_non_nullable
-              as int,
-      left: null == left
-          ? _value.left
-          : left // ignore: cast_nullable_to_non_nullable
-              as int,
-      scale: null == scale
-          ? _value.scale
-          : scale // ignore: cast_nullable_to_non_nullable
-              as double,
-      colorHex: freezed == colorHex
-          ? _value.colorHex
-          : colorHex // ignore: cast_nullable_to_non_nullable
-              as int?,
-      animationTimingFunction: null == animationTimingFunction
-          ? _value.animationTimingFunction
-          : animationTimingFunction // ignore: cast_nullable_to_non_nullable
-              as AnimationTimingFunction,
-      spinsPerSecond: null == spinsPerSecond
-          ? _value.spinsPerSecond
-          : spinsPerSecond // ignore: cast_nullable_to_non_nullable
-              as double,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
 abstract class _$$SpinnerDrawingImplCopyWith<$Res>
-    implements $SpinnerDrawingCopyWith<$Res> {
+    implements $GYWDrawingCopyWith<$Res> {
   factory _$$SpinnerDrawingImplCopyWith(_$SpinnerDrawingImpl value,
           $Res Function(_$SpinnerDrawingImpl) then) =
       __$$SpinnerDrawingImplCopyWithImpl<$Res>;
@@ -883,7 +1201,7 @@ abstract class _$$SpinnerDrawingImplCopyWith<$Res>
 
 /// @nodoc
 class __$$SpinnerDrawingImplCopyWithImpl<$Res>
-    extends _$SpinnerDrawingCopyWithImpl<$Res, _$SpinnerDrawingImpl>
+    extends _$GYWDrawingCopyWithImpl<$Res, _$SpinnerDrawingImpl>
     implements _$$SpinnerDrawingImplCopyWith<$Res> {
   __$$SpinnerDrawingImplCopyWithImpl(
       _$SpinnerDrawingImpl _value, $Res Function(_$SpinnerDrawingImpl) _then)
@@ -929,20 +1247,28 @@ class __$$SpinnerDrawingImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
-class _$SpinnerDrawingImpl extends _SpinnerDrawing {
+@JsonSerializable()
+class _$SpinnerDrawingImpl extends SpinnerDrawing {
   const _$SpinnerDrawingImpl(
       {this.top = 0,
       this.left = 0,
       this.scale = 1.0,
       this.colorHex,
       this.animationTimingFunction = AnimationTimingFunction.linear,
-      this.spinsPerSecond = 1.0})
-      : super._();
+      this.spinsPerSecond = 1.0,
+      final String? $type})
+      : $type = $type ?? 'SpinnerDrawing',
+        super._();
 
+  factory _$SpinnerDrawingImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SpinnerDrawingImplFromJson(json);
+
+  /// The distance (in pixels) from the top of the screen
   @override
   @JsonKey()
   final int top;
+
+  /// The distance (in pixels) from the left side of the screen
   @override
   @JsonKey()
   final int left;
@@ -966,9 +1292,12 @@ class _$SpinnerDrawingImpl extends _SpinnerDrawing {
   @JsonKey()
   final double spinsPerSecond;
 
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
   @override
   String toString() {
-    return 'SpinnerDrawing(top: $top, left: $left, scale: $scale, colorHex: $colorHex, animationTimingFunction: $animationTimingFunction, spinsPerSecond: $spinsPerSecond)';
+    return 'GYWDrawing.spinnerDrawing(top: $top, left: $left, scale: $scale, colorHex: $colorHex, animationTimingFunction: $animationTimingFunction, spinsPerSecond: $spinsPerSecond)';
   }
 
   @override
@@ -988,6 +1317,7 @@ class _$SpinnerDrawingImpl extends _SpinnerDrawing {
                 other.spinsPerSecond == spinsPerSecond));
   }
 
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, top, left, scale, colorHex,
       animationTimingFunction, spinsPerSecond);
@@ -998,23 +1328,171 @@ class _$SpinnerDrawingImpl extends _SpinnerDrawing {
   _$$SpinnerDrawingImplCopyWith<_$SpinnerDrawingImpl> get copyWith =>
       __$$SpinnerDrawingImplCopyWithImpl<_$SpinnerDrawingImpl>(
           this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)
+        textDrawing,
+    required TResult Function(int top, int left,
+            @GYWIconJsonConverter() GYWIcon icon, int colorHex, double scale)
+        iconDrawing,
+    required TResult Function(
+            int top, int left, int width, int height, int? colorHex)
+        rectangleDrawing,
+    required TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)
+        spinnerDrawing,
+  }) {
+    return spinnerDrawing(
+        top, left, scale, colorHex, animationTimingFunction, spinsPerSecond);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult? Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult? Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult? Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+  }) {
+    return spinnerDrawing?.call(
+        top, left, scale, colorHex, animationTimingFunction, spinsPerSecond);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(
+            int top,
+            int left,
+            String text,
+            @GYWFontJsonConverter() GYWFont? font,
+            int? size,
+            int colorHex,
+            int? maxWidth,
+            int? maxLines)?
+        textDrawing,
+    TResult Function(int top, int left, @GYWIconJsonConverter() GYWIcon icon,
+            int colorHex, double scale)?
+        iconDrawing,
+    TResult Function(int top, int left, int width, int height, int? colorHex)?
+        rectangleDrawing,
+    TResult Function(
+            int top,
+            int left,
+            double scale,
+            int? colorHex,
+            AnimationTimingFunction animationTimingFunction,
+            double spinsPerSecond)?
+        spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (spinnerDrawing != null) {
+      return spinnerDrawing(
+          top, left, scale, colorHex, animationTimingFunction, spinsPerSecond);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(TextDrawing value) textDrawing,
+    required TResult Function(IconDrawing value) iconDrawing,
+    required TResult Function(RectangleDrawing value) rectangleDrawing,
+    required TResult Function(SpinnerDrawing value) spinnerDrawing,
+  }) {
+    return spinnerDrawing(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(TextDrawing value)? textDrawing,
+    TResult? Function(IconDrawing value)? iconDrawing,
+    TResult? Function(RectangleDrawing value)? rectangleDrawing,
+    TResult? Function(SpinnerDrawing value)? spinnerDrawing,
+  }) {
+    return spinnerDrawing?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(TextDrawing value)? textDrawing,
+    TResult Function(IconDrawing value)? iconDrawing,
+    TResult Function(RectangleDrawing value)? rectangleDrawing,
+    TResult Function(SpinnerDrawing value)? spinnerDrawing,
+    required TResult orElse(),
+  }) {
+    if (spinnerDrawing != null) {
+      return spinnerDrawing(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SpinnerDrawingImplToJson(
+      this,
+    );
+  }
 }
 
-abstract class _SpinnerDrawing extends SpinnerDrawing {
-  const factory _SpinnerDrawing(
+abstract class SpinnerDrawing extends GYWDrawing {
+  const factory SpinnerDrawing(
       {final int top,
       final int left,
       final double scale,
       final int? colorHex,
       final AnimationTimingFunction animationTimingFunction,
       final double spinsPerSecond}) = _$SpinnerDrawingImpl;
-  const _SpinnerDrawing._() : super._();
+  const SpinnerDrawing._() : super._();
+
+  factory SpinnerDrawing.fromJson(Map<String, dynamic> json) =
+      _$SpinnerDrawingImpl.fromJson;
 
   @override
+
+  /// The distance (in pixels) from the top of the screen
   int get top;
   @override
+
+  /// The distance (in pixels) from the left side of the screen
   int get left;
-  @override
 
   /// The scale of the image.
   double get scale;
@@ -1022,11 +1500,9 @@ abstract class _SpinnerDrawing extends SpinnerDrawing {
 
   /// The fill color. If null, the image colors will be preserved.
   int? get colorHex;
-  @override
 
   /// The curve applied while spinning.
   AnimationTimingFunction get animationTimingFunction;
-  @override
 
   /// How many rotations per second.
   double get spinsPerSecond;

--- a/lib/src/drawings.g.dart
+++ b/lib/src/drawings.g.dart
@@ -1,0 +1,123 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'drawings.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TextDrawingImpl _$$TextDrawingImplFromJson(Map<String, dynamic> json) =>
+    _$TextDrawingImpl(
+      top: (json['top'] as num?)?.toInt() ?? 0,
+      left: (json['left'] as num?)?.toInt() ?? 0,
+      text: json['text'] as String,
+      font: _$JsonConverterFromJson<Map<String, dynamic>, GYWFont>(
+          json['font'], const GYWFontJsonConverter().fromJson),
+      size: (json['size'] as num?)?.toInt(),
+      colorHex: (json['colorHex'] as num?)?.toInt() ?? 0xFF000000,
+      maxWidth: (json['maxWidth'] as num?)?.toInt(),
+      maxLines: (json['maxLines'] as num?)?.toInt(),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$TextDrawingImplToJson(_$TextDrawingImpl instance) =>
+    <String, dynamic>{
+      'top': instance.top,
+      'left': instance.left,
+      'text': instance.text,
+      'font': _$JsonConverterToJson<Map<String, dynamic>, GYWFont>(
+          instance.font, const GYWFontJsonConverter().toJson),
+      'size': instance.size,
+      'colorHex': instance.colorHex,
+      'maxWidth': instance.maxWidth,
+      'maxLines': instance.maxLines,
+      'runtimeType': instance.$type,
+    };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
+
+_$IconDrawingImpl _$$IconDrawingImplFromJson(Map<String, dynamic> json) =>
+    _$IconDrawingImpl(
+      top: (json['top'] as num?)?.toInt() ?? 0,
+      left: (json['left'] as num?)?.toInt() ?? 0,
+      icon: const GYWIconJsonConverter()
+          .fromJson(json['icon'] as Map<String, dynamic>),
+      colorHex: (json['colorHex'] as num?)?.toInt() ?? 0xFF000000,
+      scale: (json['scale'] as num?)?.toDouble() ?? 1.0,
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$IconDrawingImplToJson(_$IconDrawingImpl instance) =>
+    <String, dynamic>{
+      'top': instance.top,
+      'left': instance.left,
+      'icon': const GYWIconJsonConverter().toJson(instance.icon),
+      'colorHex': instance.colorHex,
+      'scale': instance.scale,
+      'runtimeType': instance.$type,
+    };
+
+_$RectangleDrawingImpl _$$RectangleDrawingImplFromJson(
+        Map<String, dynamic> json) =>
+    _$RectangleDrawingImpl(
+      top: (json['top'] as num?)?.toInt() ?? 0,
+      left: (json['left'] as num?)?.toInt() ?? 0,
+      width: (json['width'] as num).toInt(),
+      height: (json['height'] as num).toInt(),
+      colorHex: (json['colorHex'] as num?)?.toInt(),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$RectangleDrawingImplToJson(
+        _$RectangleDrawingImpl instance) =>
+    <String, dynamic>{
+      'top': instance.top,
+      'left': instance.left,
+      'width': instance.width,
+      'height': instance.height,
+      'colorHex': instance.colorHex,
+      'runtimeType': instance.$type,
+    };
+
+_$SpinnerDrawingImpl _$$SpinnerDrawingImplFromJson(Map<String, dynamic> json) =>
+    _$SpinnerDrawingImpl(
+      top: (json['top'] as num?)?.toInt() ?? 0,
+      left: (json['left'] as num?)?.toInt() ?? 0,
+      scale: (json['scale'] as num?)?.toDouble() ?? 1.0,
+      colorHex: (json['colorHex'] as num?)?.toInt(),
+      animationTimingFunction: $enumDecodeNullable(
+              _$AnimationTimingFunctionEnumMap,
+              json['animationTimingFunction']) ??
+          AnimationTimingFunction.linear,
+      spinsPerSecond: (json['spinsPerSecond'] as num?)?.toDouble() ?? 1.0,
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$SpinnerDrawingImplToJson(
+        _$SpinnerDrawingImpl instance) =>
+    <String, dynamic>{
+      'top': instance.top,
+      'left': instance.left,
+      'scale': instance.scale,
+      'colorHex': instance.colorHex,
+      'animationTimingFunction':
+          _$AnimationTimingFunctionEnumMap[instance.animationTimingFunction]!,
+      'spinsPerSecond': instance.spinsPerSecond,
+      'runtimeType': instance.$type,
+    };
+
+const _$AnimationTimingFunctionEnumMap = {
+  AnimationTimingFunction.linear: 'linear',
+  AnimationTimingFunction.ease_in: 'ease_in',
+  AnimationTimingFunction.ease_out: 'ease_out',
+};

--- a/lib/src/fonts.dart
+++ b/lib/src/fonts.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:json_annotation/json_annotation.dart";
 
 /// The text fonts supported on aRdent smart glasses
 @immutable
@@ -103,4 +104,24 @@ enum GYWFonts {
   final GYWFont font;
 
   const GYWFonts(this.font);
+}
+
+/// Converts a [GYWFont] object to and from JSON.
+class GYWFontJsonConverter
+    implements JsonConverter<GYWFont, Map<String, dynamic>> {
+  /// Constructor.
+  const GYWFontJsonConverter();
+
+  @override
+  GYWFont fromJson(Map<String, dynamic> json) {
+    // TODO(arosca): Rewrite these functions once the PR on removing font prefixes gets merged.
+    return GYWFonts.values
+        .firstWhere((element) => element.font.prefix == json["prefix"])
+        .font;
+  }
+
+  @override
+  Map<String, dynamic> toJson(GYWFont object) {
+    return {"prefix": object.prefix};
+  }
 }

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:json_annotation/json_annotation.dart";
 
 /// A icon element that can be used on aRdent smart glasses.
 @immutable
@@ -61,6 +62,42 @@ class GYWIcon {
         pathPng,
         pathSvg,
       );
+}
+
+/// Converts a [GYWIcon] object to and from JSON.
+class GYWIconJsonConverter
+    implements JsonConverter<GYWIcon, Map<String, dynamic>> {
+  /// Constructor.
+  const GYWIconJsonConverter();
+
+  @override
+  GYWIcon fromJson(Map<String, dynamic> json) {
+    final String icon = json["filename"] as String;
+
+    final GYWIcon? gywIcon = GYWIcons.values
+        .cast<GYWIcons?>()
+        .firstWhere(
+          (element) => element!.icon.filename == icon,
+          orElse: () => null,
+        )
+        ?.icon;
+
+    if (gywIcon != null) {
+      return gywIcon;
+    }
+
+    return GYWIcon(
+      filename: icon,
+      name: icon,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson(GYWIcon object) {
+    return <String, dynamic>{
+      "filename": object.filename,
+    };
+  }
 }
 
 /// The [GYWIcon] icons supported by default on aRdent smart glasses.

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "package:flutter/material.dart";
 import "package:flutter_gyw/flutter_gyw.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:json_annotation/json_annotation.dart";
 
 void main() {
   group("JSON", () {
@@ -85,7 +86,10 @@ void main() {
         "data": "Test",
       };
 
-      expect(() => GYWDrawing.fromJson(json), throwsA(isA<UnsupportedError>()));
+      expect(
+        () => GYWDrawing.fromJson(json),
+        throwsA(isA<CheckedFromJsonException>()),
+      );
     });
   });
 


### PR DESCRIPTION
By unionizing all the drawings, `freezed` can use json_serializer to generate `fromJson` and `toJson` methods for each one of them.

As `GYWIcon` and `GYWFont` are not `freezed` classes, a custom JSON converter was necessary, so `freezed` knows how to serialize those classes.

QOL functions like the color method on some drawings had to be attached to their respective drawings using an extension because the concrete drawing classes are defined by `freezed`, not by us.