### PR TITLE
Replace manual serialization code with dart_mappable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mapper.dart linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [REFACTOR] Make `maxLines` nullable
 * [REFACTOR] Simplify the use of user-defined icons
 * [REFACTOR] Remove font prefixes
+* [REFACTOR] Replace manual serialization code with dart_mappable
 
 ## 1.2.1
 * [ADD] Add spinner image

--- a/lib/src/custom_mappers.dart
+++ b/lib/src/custom_mappers.dart
@@ -1,0 +1,51 @@
+import "package:dart_mappable/dart_mappable.dart";
+import "package:flutter_gyw/flutter_gyw.dart";
+
+/// A custom mapper for [GYWIcon].
+class GYWIconMapper extends SimpleMapper<GYWIcon> {
+  /// Constructor.
+  const GYWIconMapper();
+
+  @override
+  GYWIcon decode(dynamic value) {
+    final String filename = value as String;
+
+    final GYWIcon? icon = GYWIcons.values
+        .cast<GYWIcons?>()
+        .firstWhere(
+          (element) => element!.icon.filename == filename,
+          orElse: () => null,
+        )
+        ?.icon;
+
+    return icon ?? GYWIcon(name: filename, filename: filename);
+  }
+
+  @override
+  dynamic encode(GYWIcon self) {
+    return self.filename;
+  }
+}
+
+/// A custom mapper for [GYWFont].
+class GYWFontMapper extends SimpleMapper<GYWFont> {
+  /// Constructor.
+  const GYWFontMapper();
+
+  @override
+  GYWFont decode(dynamic value) {
+    final String filename = value as String;
+
+    return GYWFonts.values
+        .firstWhere(
+          (element) => element.font.filename == filename,
+          orElse: () => GYWFonts.robotoMono,
+        )
+        .font;
+  }
+
+  @override
+  dynamic encode(GYWFont self) {
+    return self.filename;
+  }
+}

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -14,15 +14,6 @@ import "screen.dart";
 part "drawings.mapper.dart";
 
 /// A drawing that can be displayed on a pair of aRdent smart glasses
-abstract interface class Drawing {
-  /// The distance (in pixels) from the top of the screen
-  int get top;
-
-  /// The distance (in pixels) from the top of the screen
-  int get left;
-}
-
-/// A drawing that can be displayed on a pair of aRdent smart glasses
 @immutable
 @MappableClass(
   discriminatorKey: "type",
@@ -31,11 +22,11 @@ abstract interface class Drawing {
     GYWFontMapper(),
   ],
 )
-sealed class GYWDrawing with GYWDrawingMappable implements Drawing {
-  @override
+sealed class GYWDrawing with GYWDrawingMappable {
+  /// The distance (in pixels) from the top of the screen
   final int top;
 
-  @override
+  /// The distance (in pixels) from the top of the screen
   final int left;
 
   /// Abstract const contructor.

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -62,6 +62,7 @@ class TextDrawing extends GYWDrawing with TextDrawingMappable {
   final int size;
 
   /// Text color in hexadecimal format.
+  @MappableField(key: "color")
   final int colorHex;
 
   /// Text color.
@@ -184,6 +185,7 @@ class IconDrawing extends GYWDrawing with IconDrawingMappable {
   final GYWIcon icon;
 
   /// Hexadecimal code of the icon fill color
+  @MappableField(key: "color")
   final int colorHex;
 
   /// Fill color.
@@ -241,6 +243,7 @@ class RectangleDrawing extends GYWDrawing with RectangleDrawingMappable {
   final int height;
 
   /// The fill color. If null, the rectangle will use the current background color.
+  @MappableField(key: "color")
   final int? colorHex;
 
   /// Fill color.
@@ -287,6 +290,7 @@ class SpinnerDrawing extends GYWDrawing with SpinnerDrawingMappable {
   final double scale;
 
   /// The fill color. If null, the image colors will be preserved.
+  @MappableField(key: "color")
   final int? colorHex;
 
   /// Fill color.

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -3,11 +3,11 @@ import "dart:typed_data";
 
 import "package:dart_mappable/dart_mappable.dart";
 import "package:flutter/material.dart";
-import "package:flutter_gyw/src/custom_mappers.dart";
-import "package:flutter_gyw/src/helpers.dart";
 
 import "commands.dart";
+import "custom_mappers.dart";
 import "fonts.dart";
+import "helpers.dart";
 import "icons.dart";
 import "screen.dart";
 

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -16,6 +16,7 @@ part "drawings.mapper.dart";
 /// A drawing that can be displayed on a pair of aRdent smart glasses
 @immutable
 @MappableClass(
+  caseStyle: CaseStyle.snakeCase,
   discriminatorKey: "type",
   includeCustomMappers: [
     GYWIconMapper(),

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -14,6 +14,15 @@ import "screen.dart";
 part "drawings.mapper.dart";
 
 /// A drawing that can be displayed on a pair of aRdent smart glasses
+abstract interface class Drawing {
+  /// The distance (in pixels) from the top of the screen
+  int get top;
+
+  /// The distance (in pixels) from the top of the screen
+  int get left;
+}
+
+/// A drawing that can be displayed on a pair of aRdent smart glasses
 @immutable
 @MappableClass(
   discriminatorKey: "type",
@@ -22,11 +31,11 @@ part "drawings.mapper.dart";
     GYWFontMapper(),
   ],
 )
-sealed class GYWDrawing with GYWDrawingMappable {
-  /// The distance (in pixels) from the top of the screen
+sealed class GYWDrawing with GYWDrawingMappable implements Drawing {
+  @override
   final int top;
 
-  /// The distance (in pixels) from the left side of the screen
+  @override
   final int left;
 
   /// Abstract const contructor.

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -88,7 +88,7 @@ class TextDrawing extends GYWDrawing with TextDrawingMappable {
   final int? maxLines;
 
   /// Creates a text element.
-  TextDrawing({
+  const TextDrawing({
     required this.text,
     this.font = robotoMonoFont,
     this.size = 24,

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -338,6 +338,7 @@ class SpinnerDrawing extends GYWDrawing with SpinnerDrawingMappable {
 }
 
 /// The animations for spinner rotating behaviour
+@MappableEnum()
 enum AnimationTimingFunction {
   /// Linear timing function
   linear(0),

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -1,7 +1,9 @@
 import "dart:convert";
 import "dart:typed_data";
 
+import "package:dart_mappable/dart_mappable.dart";
 import "package:flutter/material.dart";
+import "package:flutter_gyw/src/custom_mappers.dart";
 import "package:flutter_gyw/src/helpers.dart";
 
 import "commands.dart";
@@ -9,9 +11,18 @@ import "fonts.dart";
 import "icons.dart";
 import "screen.dart";
 
+part "drawings.mapper.dart";
+
 /// A drawing that can be displayed on a pair of aRdent smart glasses
 @immutable
-abstract class GYWDrawing {
+@MappableClass(
+  discriminatorKey: "type",
+  includeCustomMappers: [
+    GYWIconMapper(),
+    GYWFontMapper(),
+  ],
+)
+sealed class GYWDrawing with GYWDrawingMappable {
   /// The distance (in pixels) from the top of the screen
   final int top;
 
@@ -24,35 +35,19 @@ abstract class GYWDrawing {
     this.left = 0,
   });
 
+  /// Deserializes a drawing from a map
+  static const fromMap = GYWDrawingMapper.fromMap;
+
+  /// Deserializes a drawing from a JSON string
+  static const fromJson = GYWDrawingMapper.fromJson;
+
   /// Converts the drawing into a list of commands understood by the device
   List<GYWBtCommand> toCommands();
-
-  /// Deserializes a [GYWDrawing] from JSON data
-  factory GYWDrawing.fromJson(Map<String, dynamic> data) {
-    switch (data["type"]) {
-      case TextDrawing.type:
-        return TextDrawing.fromJson(data);
-      case IconDrawing.type:
-        return IconDrawing.fromJson(data);
-      case RectangleDrawing.type:
-        return RectangleDrawing.fromJson(data);
-      case SpinnerDrawing.type:
-        return SpinnerDrawing.fromJson(data);
-      default:
-        throw UnsupportedError("Type '${data['type']}' is not supported.");
-    }
-  }
-
-  /// Serializes a drawing to JSON data
-  Map<String, dynamic> toJson();
 }
 
 /// A drawing to display text on an aRdent device
-@immutable
-class TextDrawing extends GYWDrawing {
-  /// The type of the [TextDrawing] drawing
-  static const String type = "text";
-
+@MappableClass()
+class TextDrawing extends GYWDrawing with TextDrawingMappable {
   /// The text that must be displayed
   final String text;
 
@@ -65,8 +60,11 @@ class TextDrawing extends GYWDrawing {
   /// The text size.
   final int size;
 
-  /// The color of the text.
-  final Color color;
+  /// Text color in hexadecimal format.
+  final int colorHex;
+
+  /// Text color.
+  Color get color => Color(colorHex);
 
   /// The maximum width (in pixels) of the text.
   ///
@@ -81,16 +79,22 @@ class TextDrawing extends GYWDrawing {
   final int? maxLines;
 
   /// Creates a text element.
-  const TextDrawing({
+  TextDrawing({
     required this.text,
     this.font = robotoMonoFont,
     this.size = 24,
-    this.color = Colors.black,
+    this.colorHex = 0xFF000000, // black
     this.maxWidth,
     this.maxLines = 1,
     super.left = 0,
     super.top = 0,
   });
+
+  /// Deserializes a text drawing from a map
+  static const fromMap = TextDrawingMapper.fromMap;
+
+  /// Deserializes a text drawing from a JSON string
+  static const fromJson = TextDrawingMapper.fromJson;
 
   @override
   List<GYWBtCommand> toCommands() {
@@ -170,88 +174,19 @@ class TextDrawing extends GYWDrawing {
       ),
     ];
   }
-
-  @override
-  String toString() {
-    return "Drawing: Text '$text' with $font at ($left, $top)";
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (other is TextDrawing) {
-      return text == other.text &&
-          left == other.left &&
-          top == other.top &&
-          font == other.font &&
-          size == other.size &&
-          color.value == other.color.value &&
-          maxWidth == other.maxWidth &&
-          maxLines == other.maxLines;
-    } else {
-      return false;
-    }
-  }
-
-  @override
-  int get hashCode => Object.hash(
-        text,
-        font,
-        left,
-        top,
-        size,
-        color,
-        maxWidth,
-        maxLines,
-      );
-
-  /// Deserializes a [TextDrawing] from JSON data
-  factory TextDrawing.fromJson(Map<String, dynamic> data) {
-    final font = GYWFonts.values
-        .firstWhere(
-          (e) => e.font.filename == data["font"],
-          orElse: () => GYWFonts.robotoMono,
-        )
-        .font;
-
-    return TextDrawing(
-      left: data["left"] as int,
-      top: data["top"] as int,
-      text: data["data"] as String,
-      font: font,
-      size: data["size"] as int,
-      color: colorFromHex(data["color"] as String?) ?? Colors.black,
-      maxWidth: data["max_width"] as int?,
-      maxLines: data["max_lines"] as int? ?? 1,
-    );
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return {
-      "type": type,
-      "left": left,
-      "top": top,
-      "data": text,
-      "font": font.filename,
-      "size": size,
-      "color": hexFromColor(color),
-      "max_width": maxWidth,
-      "max_lines": maxLines,
-    };
-  }
 }
 
 /// A drawing to display an icon on an aRdent device
-@immutable
-class IconDrawing extends GYWDrawing {
-  /// The type of the [IconDrawing]
-  static const String type = "icon";
-
+@MappableClass()
+class IconDrawing extends GYWDrawing with IconDrawingMappable {
   /// The displayed [GYWIcon]
   final GYWIcon icon;
 
   /// Hexadecimal code of the icon fill color
-  final Color color;
+  final int colorHex;
+
+  /// Fill color.
+  Color get color => Color(colorHex);
 
   /// The icon scaling factor.
   ///
@@ -263,9 +198,15 @@ class IconDrawing extends GYWDrawing {
     this.icon, {
     super.top,
     super.left,
-    this.color = Colors.black,
+    this.colorHex = 0xFF000000,
     this.scale = 1.0,
   });
+
+  /// Deserializes an icon drawing from a map
+  static const fromMap = IconDrawingMapper.fromMap;
+
+  /// Deserializes an icon drawing from a JSON string
+  static const fromJson = IconDrawingMapper.fromJson;
 
   @override
   List<GYWBtCommand> toCommands() {
@@ -287,84 +228,11 @@ class IconDrawing extends GYWDrawing {
       ),
     ];
   }
-
-  @override
-  String toString() {
-    return "Drawing: ${icon.name} at ($left, $top)";
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (other is IconDrawing) {
-      return icon == other.icon &&
-          color.value == other.color.value &&
-          left == other.left &&
-          top == other.top &&
-          scale == other.scale;
-    } else {
-      return false;
-    }
-  }
-
-  @override
-  int get hashCode => Object.hash(
-        icon,
-        left,
-        top,
-        color,
-        scale,
-      );
-
-  /// Deserializes an [IconDrawing] from JSON data
-  factory IconDrawing.fromJson(Map<String, dynamic> data) {
-    final String icon = data["data"] as String;
-
-    final GYWIcon? gywIcon = GYWIcons.values
-        .cast<GYWIcons?>()
-        .firstWhere(
-          (element) => element!.icon.filename == icon,
-          orElse: () => null,
-        )
-        ?.icon;
-
-    if (gywIcon != null) {
-      return IconDrawing(
-        gywIcon,
-        left: data["left"] as int,
-        top: data["top"] as int,
-        color: colorFromHex(data["color"] as String?) ?? Colors.black,
-        scale: (data["scale"] as num? ?? 1.0).toDouble(),
-      );
-    } else {
-      return IconDrawing(
-        GYWIcon(name: icon, filename: icon),
-        left: data["left"] as int,
-        top: data["top"] as int,
-        color: colorFromHex(data["color"] as String?) ?? Colors.black,
-        scale: (data["scale"] as num? ?? 1.0).toDouble(),
-      );
-    }
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return {
-      "type": type,
-      "left": left,
-      "top": top,
-      "data": icon.filename,
-      "color": hexFromColor(color),
-      "scale": scale,
-    };
-  }
 }
 
 /// A drawing to display a rectangle on an aRdent device
-@immutable
-class RectangleDrawing extends GYWDrawing {
-  /// The type of the [RectangleDrawing].
-  static const String type = "rectangle";
-
+@MappableClass()
+class RectangleDrawing extends GYWDrawing with RectangleDrawingMappable {
   /// The rectangle width.
   final int width;
 
@@ -372,7 +240,10 @@ class RectangleDrawing extends GYWDrawing {
   final int height;
 
   /// The fill color. If null, the rectangle will use the current background color.
-  final Color? color;
+  final int? colorHex;
+
+  /// Fill color.
+  Color? get color => colorHex != null ? Color(colorHex!) : null;
 
   /// Creates a rectangle element.
   const RectangleDrawing({
@@ -380,8 +251,14 @@ class RectangleDrawing extends GYWDrawing {
     super.top,
     required this.width,
     required this.height,
-    this.color,
+    this.colorHex,
   });
+
+  /// Deserializes a rectangle drawing from a map
+  static const fromMap = RectangleDrawingMapper.fromMap;
+
+  /// Deserializes a rectangle drawing from a JSON string
+  static const fromJson = RectangleDrawingMapper.fromJson;
 
   @override
   List<GYWBtCommand> toCommands() {
@@ -400,67 +277,19 @@ class RectangleDrawing extends GYWDrawing {
       ),
     ];
   }
-
-  @override
-  String toString() {
-    return "RectangleDrawing{left: $left, top: $top, width: $width, height: $height, color: $color}";
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RectangleDrawing &&
-          runtimeType == other.runtimeType &&
-          left == other.left &&
-          top == other.top &&
-          width == other.width &&
-          height == other.height &&
-          color?.value == other.color?.value;
-
-  @override
-  int get hashCode => Object.hash(
-        left,
-        top,
-        width,
-        height,
-        color,
-      );
-
-  /// Deserializes a [RectangleDrawing] from JSON data
-  factory RectangleDrawing.fromJson(Map<String, dynamic> data) {
-    return RectangleDrawing(
-      left: data["left"] as int,
-      top: data["top"] as int,
-      width: data["width"] as int,
-      height: data["height"] as int,
-      color: colorFromHex(data["color"] as String?),
-    );
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return {
-      "type": type,
-      "left": left,
-      "top": top,
-      "width": width,
-      "height": height,
-      "color": color != null ? hexFromColor(color!) : null,
-    };
-  }
 }
 
 /// A drawing to display a spinner on an aRdent device
-@immutable
-class SpinnerDrawing extends GYWDrawing {
-  /// The type of the [SpinnerDrawing].
-  static const String type = "spinner";
-
+@MappableClass()
+class SpinnerDrawing extends GYWDrawing with SpinnerDrawingMappable {
   /// The scale of the image.
   final double scale;
 
   /// The fill color. If null, the image colors will be preserved.
-  final Color? color;
+  final int? colorHex;
+
+  /// Fill color.
+  Color? get color => colorHex != null ? Color(colorHex!) : null;
 
   /// The curve applied while spinning.
   final AnimationTimingFunction animationTimingFunction;
@@ -473,10 +302,16 @@ class SpinnerDrawing extends GYWDrawing {
     super.left,
     super.top,
     this.scale = 1.0,
-    this.color,
+    this.colorHex,
     this.animationTimingFunction = AnimationTimingFunction.linear,
     this.spinsPerSecond = 1.0,
   });
+
+  /// Deserializes a spinner drawing from a map
+  static const fromMap = SpinnerDrawingMapper.fromMap;
+
+  /// Deserializes a spinner drawing from a JSON string
+  static const fromJson = SpinnerDrawingMapper.fromJson;
 
   @override
   List<GYWBtCommand> toCommands() {
@@ -499,68 +334,6 @@ class SpinnerDrawing extends GYWDrawing {
         controlBytes.toBytes(),
       ),
     ];
-  }
-
-  @override
-  String toString() {
-    return """
-SpinnerDrawing{
-  left: $left,
-  top: $top,
-  color: $color,
-  scale: $scale,
-  animationTimingFunction: $animationTimingFunction,
-  spinsPerSecond: $spinsPerSecond,
-}""";
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is SpinnerDrawing &&
-          runtimeType == other.runtimeType &&
-          left == other.left &&
-          top == other.top &&
-          scale == other.scale &&
-          color?.value == other.color?.value &&
-          animationTimingFunction == other.animationTimingFunction &&
-          spinsPerSecond == other.spinsPerSecond;
-
-  @override
-  int get hashCode => Object.hash(
-        left,
-        top,
-        scale,
-        color,
-        animationTimingFunction,
-        spinsPerSecond,
-      );
-
-  /// Deserializes a [RectangleDrawing] from JSON data
-  factory SpinnerDrawing.fromJson(Map<String, dynamic> data) {
-    return SpinnerDrawing(
-      left: data["left"] as int,
-      top: data["top"] as int,
-      scale: (data["scale"] as num).toDouble(),
-      color: colorFromHex(data["color"] as String?),
-      animationTimingFunction: AnimationTimingFunction.values.byName(
-        data["animation_timing_function"] as String,
-      ),
-      spinsPerSecond: (data["spins_per_second"] as num).toDouble(),
-    );
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return {
-      "type": type,
-      "left": left,
-      "top": top,
-      "scale": scale,
-      "color": color != null ? hexFromColor(color!) : null,
-      "animation_timing_function": animationTimingFunction.name,
-      "spins_per_second": spinsPerSecond,
-    };
   }
 }
 

--- a/lib/src/drawings.mapper.dart
+++ b/lib/src/drawings.mapper.dart
@@ -6,6 +6,59 @@
 
 part of 'drawings.dart';
 
+class AnimationTimingFunctionMapper
+    extends EnumMapper<AnimationTimingFunction> {
+  AnimationTimingFunctionMapper._();
+
+  static AnimationTimingFunctionMapper? _instance;
+  static AnimationTimingFunctionMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals
+          .use(_instance = AnimationTimingFunctionMapper._());
+    }
+    return _instance!;
+  }
+
+  static AnimationTimingFunction fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  AnimationTimingFunction decode(dynamic value) {
+    switch (value) {
+      case 'linear':
+        return AnimationTimingFunction.linear;
+      case 'ease_in':
+        return AnimationTimingFunction.ease_in;
+      case 'ease_out':
+        return AnimationTimingFunction.ease_out;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(AnimationTimingFunction self) {
+    switch (self) {
+      case AnimationTimingFunction.linear:
+        return 'linear';
+      case AnimationTimingFunction.ease_in:
+        return 'ease_in';
+      case AnimationTimingFunction.ease_out:
+        return 'ease_out';
+    }
+  }
+}
+
+extension AnimationTimingFunctionMapperExtension on AnimationTimingFunction {
+  String toValue() {
+    AnimationTimingFunctionMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<AnimationTimingFunction>(this)
+        as String;
+  }
+}
+
 class GYWDrawingMapper extends ClassMapperBase<GYWDrawing> {
   GYWDrawingMapper._();
 
@@ -546,6 +599,7 @@ class SpinnerDrawingMapper extends SubClassMapperBase<SpinnerDrawing> {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = SpinnerDrawingMapper._());
       GYWDrawingMapper.ensureInitialized().addSubMapper(_instance!);
+      AnimationTimingFunctionMapper.ensureInitialized();
     }
     return _instance!;
   }

--- a/lib/src/drawings.mapper.dart
+++ b/lib/src/drawings.mapper.dart
@@ -1,0 +1,709 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'drawings.dart';
+
+class GYWDrawingMapper extends ClassMapperBase<GYWDrawing> {
+  GYWDrawingMapper._();
+
+  static GYWDrawingMapper? _instance;
+  static GYWDrawingMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = GYWDrawingMapper._());
+      MapperContainer.globals.useAll([GYWIconMapper(), GYWFontMapper()]);
+      TextDrawingMapper.ensureInitialized();
+      IconDrawingMapper.ensureInitialized();
+      RectangleDrawingMapper.ensureInitialized();
+      SpinnerDrawingMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'GYWDrawing';
+
+  static int _$top(GYWDrawing v) => v.top;
+  static const Field<GYWDrawing, int> _f$top =
+      Field('top', _$top, opt: true, def: 0);
+  static int _$left(GYWDrawing v) => v.left;
+  static const Field<GYWDrawing, int> _f$left =
+      Field('left', _$left, opt: true, def: 0);
+
+  @override
+  final MappableFields<GYWDrawing> fields = const {
+    #top: _f$top,
+    #left: _f$left,
+  };
+
+  static GYWDrawing _instantiate(DecodingData data) {
+    throw MapperException.missingSubclass(
+        'GYWDrawing', 'type', '${data.value['type']}');
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static GYWDrawing fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<GYWDrawing>(map);
+  }
+
+  static GYWDrawing fromJson(String json) {
+    return ensureInitialized().decodeJson<GYWDrawing>(json);
+  }
+}
+
+mixin GYWDrawingMappable {
+  String toJson();
+  Map<String, dynamic> toMap();
+  GYWDrawingCopyWith<GYWDrawing, GYWDrawing, GYWDrawing> get copyWith;
+}
+
+abstract class GYWDrawingCopyWith<$R, $In extends GYWDrawing, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({int? top, int? left});
+  GYWDrawingCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class TextDrawingMapper extends SubClassMapperBase<TextDrawing> {
+  TextDrawingMapper._();
+
+  static TextDrawingMapper? _instance;
+  static TextDrawingMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TextDrawingMapper._());
+      GYWDrawingMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TextDrawing';
+
+  static String _$text(TextDrawing v) => v.text;
+  static const Field<TextDrawing, String> _f$text = Field('text', _$text);
+  static GYWFont _$font(TextDrawing v) => v.font;
+  static const Field<TextDrawing, GYWFont> _f$font =
+      Field('font', _$font, opt: true, def: robotoMonoFont);
+  static int _$size(TextDrawing v) => v.size;
+  static const Field<TextDrawing, int> _f$size =
+      Field('size', _$size, opt: true, def: 24);
+  static int _$colorHex(TextDrawing v) => v.colorHex;
+  static const Field<TextDrawing, int> _f$colorHex =
+      Field('colorHex', _$colorHex, opt: true, def: 0xFF000000);
+  static int? _$maxWidth(TextDrawing v) => v.maxWidth;
+  static const Field<TextDrawing, int> _f$maxWidth =
+      Field('maxWidth', _$maxWidth, opt: true);
+  static int? _$maxLines(TextDrawing v) => v.maxLines;
+  static const Field<TextDrawing, int> _f$maxLines =
+      Field('maxLines', _$maxLines, opt: true, def: 1);
+  static int _$left(TextDrawing v) => v.left;
+  static const Field<TextDrawing, int> _f$left =
+      Field('left', _$left, opt: true, def: 0);
+  static int _$top(TextDrawing v) => v.top;
+  static const Field<TextDrawing, int> _f$top =
+      Field('top', _$top, opt: true, def: 0);
+
+  @override
+  final MappableFields<TextDrawing> fields = const {
+    #text: _f$text,
+    #font: _f$font,
+    #size: _f$size,
+    #colorHex: _f$colorHex,
+    #maxWidth: _f$maxWidth,
+    #maxLines: _f$maxLines,
+    #left: _f$left,
+    #top: _f$top,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = 'TextDrawing';
+  @override
+  late final ClassMapperBase superMapper = GYWDrawingMapper.ensureInitialized();
+
+  static TextDrawing _instantiate(DecodingData data) {
+    return TextDrawing(
+        text: data.dec(_f$text),
+        font: data.dec(_f$font),
+        size: data.dec(_f$size),
+        colorHex: data.dec(_f$colorHex),
+        maxWidth: data.dec(_f$maxWidth),
+        maxLines: data.dec(_f$maxLines),
+        left: data.dec(_f$left),
+        top: data.dec(_f$top));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TextDrawing fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TextDrawing>(map);
+  }
+
+  static TextDrawing fromJson(String json) {
+    return ensureInitialized().decodeJson<TextDrawing>(json);
+  }
+}
+
+mixin TextDrawingMappable {
+  String toJson() {
+    return TextDrawingMapper.ensureInitialized()
+        .encodeJson<TextDrawing>(this as TextDrawing);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TextDrawingMapper.ensureInitialized()
+        .encodeMap<TextDrawing>(this as TextDrawing);
+  }
+
+  TextDrawingCopyWith<TextDrawing, TextDrawing, TextDrawing> get copyWith =>
+      _TextDrawingCopyWithImpl(this as TextDrawing, $identity, $identity);
+  @override
+  String toString() {
+    return TextDrawingMapper.ensureInitialized()
+        .stringifyValue(this as TextDrawing);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TextDrawingMapper.ensureInitialized()
+        .equalsValue(this as TextDrawing, other);
+  }
+
+  @override
+  int get hashCode {
+    return TextDrawingMapper.ensureInitialized().hashValue(this as TextDrawing);
+  }
+}
+
+extension TextDrawingValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TextDrawing, $Out> {
+  TextDrawingCopyWith<$R, TextDrawing, $Out> get $asTextDrawing =>
+      $base.as((v, t, t2) => _TextDrawingCopyWithImpl(v, t, t2));
+}
+
+abstract class TextDrawingCopyWith<$R, $In extends TextDrawing, $Out>
+    implements GYWDrawingCopyWith<$R, $In, $Out> {
+  @override
+  $R call(
+      {String? text,
+      GYWFont? font,
+      int? size,
+      int? colorHex,
+      int? maxWidth,
+      int? maxLines,
+      int? left,
+      int? top});
+  TextDrawingCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _TextDrawingCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TextDrawing, $Out>
+    implements TextDrawingCopyWith<$R, TextDrawing, $Out> {
+  _TextDrawingCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TextDrawing> $mapper =
+      TextDrawingMapper.ensureInitialized();
+  @override
+  $R call(
+          {String? text,
+          GYWFont? font,
+          int? size,
+          int? colorHex,
+          Object? maxWidth = $none,
+          Object? maxLines = $none,
+          int? left,
+          int? top}) =>
+      $apply(FieldCopyWithData({
+        if (text != null) #text: text,
+        if (font != null) #font: font,
+        if (size != null) #size: size,
+        if (colorHex != null) #colorHex: colorHex,
+        if (maxWidth != $none) #maxWidth: maxWidth,
+        if (maxLines != $none) #maxLines: maxLines,
+        if (left != null) #left: left,
+        if (top != null) #top: top
+      }));
+  @override
+  TextDrawing $make(CopyWithData data) => TextDrawing(
+      text: data.get(#text, or: $value.text),
+      font: data.get(#font, or: $value.font),
+      size: data.get(#size, or: $value.size),
+      colorHex: data.get(#colorHex, or: $value.colorHex),
+      maxWidth: data.get(#maxWidth, or: $value.maxWidth),
+      maxLines: data.get(#maxLines, or: $value.maxLines),
+      left: data.get(#left, or: $value.left),
+      top: data.get(#top, or: $value.top));
+
+  @override
+  TextDrawingCopyWith<$R2, TextDrawing, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TextDrawingCopyWithImpl($value, $cast, t);
+}
+
+class IconDrawingMapper extends SubClassMapperBase<IconDrawing> {
+  IconDrawingMapper._();
+
+  static IconDrawingMapper? _instance;
+  static IconDrawingMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = IconDrawingMapper._());
+      GYWDrawingMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'IconDrawing';
+
+  static GYWIcon _$icon(IconDrawing v) => v.icon;
+  static const Field<IconDrawing, GYWIcon> _f$icon = Field('icon', _$icon);
+  static int _$top(IconDrawing v) => v.top;
+  static const Field<IconDrawing, int> _f$top =
+      Field('top', _$top, opt: true, def: 0);
+  static int _$left(IconDrawing v) => v.left;
+  static const Field<IconDrawing, int> _f$left =
+      Field('left', _$left, opt: true, def: 0);
+  static int _$colorHex(IconDrawing v) => v.colorHex;
+  static const Field<IconDrawing, int> _f$colorHex =
+      Field('colorHex', _$colorHex, opt: true, def: 0xFF000000);
+  static double _$scale(IconDrawing v) => v.scale;
+  static const Field<IconDrawing, double> _f$scale =
+      Field('scale', _$scale, opt: true, def: 1.0);
+
+  @override
+  final MappableFields<IconDrawing> fields = const {
+    #icon: _f$icon,
+    #top: _f$top,
+    #left: _f$left,
+    #colorHex: _f$colorHex,
+    #scale: _f$scale,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = 'IconDrawing';
+  @override
+  late final ClassMapperBase superMapper = GYWDrawingMapper.ensureInitialized();
+
+  static IconDrawing _instantiate(DecodingData data) {
+    return IconDrawing(data.dec(_f$icon),
+        top: data.dec(_f$top),
+        left: data.dec(_f$left),
+        colorHex: data.dec(_f$colorHex),
+        scale: data.dec(_f$scale));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static IconDrawing fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<IconDrawing>(map);
+  }
+
+  static IconDrawing fromJson(String json) {
+    return ensureInitialized().decodeJson<IconDrawing>(json);
+  }
+}
+
+mixin IconDrawingMappable {
+  String toJson() {
+    return IconDrawingMapper.ensureInitialized()
+        .encodeJson<IconDrawing>(this as IconDrawing);
+  }
+
+  Map<String, dynamic> toMap() {
+    return IconDrawingMapper.ensureInitialized()
+        .encodeMap<IconDrawing>(this as IconDrawing);
+  }
+
+  IconDrawingCopyWith<IconDrawing, IconDrawing, IconDrawing> get copyWith =>
+      _IconDrawingCopyWithImpl(this as IconDrawing, $identity, $identity);
+  @override
+  String toString() {
+    return IconDrawingMapper.ensureInitialized()
+        .stringifyValue(this as IconDrawing);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return IconDrawingMapper.ensureInitialized()
+        .equalsValue(this as IconDrawing, other);
+  }
+
+  @override
+  int get hashCode {
+    return IconDrawingMapper.ensureInitialized().hashValue(this as IconDrawing);
+  }
+}
+
+extension IconDrawingValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, IconDrawing, $Out> {
+  IconDrawingCopyWith<$R, IconDrawing, $Out> get $asIconDrawing =>
+      $base.as((v, t, t2) => _IconDrawingCopyWithImpl(v, t, t2));
+}
+
+abstract class IconDrawingCopyWith<$R, $In extends IconDrawing, $Out>
+    implements GYWDrawingCopyWith<$R, $In, $Out> {
+  @override
+  $R call({GYWIcon? icon, int? top, int? left, int? colorHex, double? scale});
+  IconDrawingCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _IconDrawingCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, IconDrawing, $Out>
+    implements IconDrawingCopyWith<$R, IconDrawing, $Out> {
+  _IconDrawingCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<IconDrawing> $mapper =
+      IconDrawingMapper.ensureInitialized();
+  @override
+  $R call({GYWIcon? icon, int? top, int? left, int? colorHex, double? scale}) =>
+      $apply(FieldCopyWithData({
+        if (icon != null) #icon: icon,
+        if (top != null) #top: top,
+        if (left != null) #left: left,
+        if (colorHex != null) #colorHex: colorHex,
+        if (scale != null) #scale: scale
+      }));
+  @override
+  IconDrawing $make(CopyWithData data) =>
+      IconDrawing(data.get(#icon, or: $value.icon),
+          top: data.get(#top, or: $value.top),
+          left: data.get(#left, or: $value.left),
+          colorHex: data.get(#colorHex, or: $value.colorHex),
+          scale: data.get(#scale, or: $value.scale));
+
+  @override
+  IconDrawingCopyWith<$R2, IconDrawing, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _IconDrawingCopyWithImpl($value, $cast, t);
+}
+
+class RectangleDrawingMapper extends SubClassMapperBase<RectangleDrawing> {
+  RectangleDrawingMapper._();
+
+  static RectangleDrawingMapper? _instance;
+  static RectangleDrawingMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = RectangleDrawingMapper._());
+      GYWDrawingMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'RectangleDrawing';
+
+  static int _$left(RectangleDrawing v) => v.left;
+  static const Field<RectangleDrawing, int> _f$left =
+      Field('left', _$left, opt: true, def: 0);
+  static int _$top(RectangleDrawing v) => v.top;
+  static const Field<RectangleDrawing, int> _f$top =
+      Field('top', _$top, opt: true, def: 0);
+  static int _$width(RectangleDrawing v) => v.width;
+  static const Field<RectangleDrawing, int> _f$width = Field('width', _$width);
+  static int _$height(RectangleDrawing v) => v.height;
+  static const Field<RectangleDrawing, int> _f$height =
+      Field('height', _$height);
+  static int? _$colorHex(RectangleDrawing v) => v.colorHex;
+  static const Field<RectangleDrawing, int> _f$colorHex =
+      Field('colorHex', _$colorHex, opt: true);
+
+  @override
+  final MappableFields<RectangleDrawing> fields = const {
+    #left: _f$left,
+    #top: _f$top,
+    #width: _f$width,
+    #height: _f$height,
+    #colorHex: _f$colorHex,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = 'RectangleDrawing';
+  @override
+  late final ClassMapperBase superMapper = GYWDrawingMapper.ensureInitialized();
+
+  static RectangleDrawing _instantiate(DecodingData data) {
+    return RectangleDrawing(
+        left: data.dec(_f$left),
+        top: data.dec(_f$top),
+        width: data.dec(_f$width),
+        height: data.dec(_f$height),
+        colorHex: data.dec(_f$colorHex));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static RectangleDrawing fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<RectangleDrawing>(map);
+  }
+
+  static RectangleDrawing fromJson(String json) {
+    return ensureInitialized().decodeJson<RectangleDrawing>(json);
+  }
+}
+
+mixin RectangleDrawingMappable {
+  String toJson() {
+    return RectangleDrawingMapper.ensureInitialized()
+        .encodeJson<RectangleDrawing>(this as RectangleDrawing);
+  }
+
+  Map<String, dynamic> toMap() {
+    return RectangleDrawingMapper.ensureInitialized()
+        .encodeMap<RectangleDrawing>(this as RectangleDrawing);
+  }
+
+  RectangleDrawingCopyWith<RectangleDrawing, RectangleDrawing, RectangleDrawing>
+      get copyWith => _RectangleDrawingCopyWithImpl(
+          this as RectangleDrawing, $identity, $identity);
+  @override
+  String toString() {
+    return RectangleDrawingMapper.ensureInitialized()
+        .stringifyValue(this as RectangleDrawing);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return RectangleDrawingMapper.ensureInitialized()
+        .equalsValue(this as RectangleDrawing, other);
+  }
+
+  @override
+  int get hashCode {
+    return RectangleDrawingMapper.ensureInitialized()
+        .hashValue(this as RectangleDrawing);
+  }
+}
+
+extension RectangleDrawingValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, RectangleDrawing, $Out> {
+  RectangleDrawingCopyWith<$R, RectangleDrawing, $Out>
+      get $asRectangleDrawing =>
+          $base.as((v, t, t2) => _RectangleDrawingCopyWithImpl(v, t, t2));
+}
+
+abstract class RectangleDrawingCopyWith<$R, $In extends RectangleDrawing, $Out>
+    implements GYWDrawingCopyWith<$R, $In, $Out> {
+  @override
+  $R call({int? left, int? top, int? width, int? height, int? colorHex});
+  RectangleDrawingCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+      Then<$Out2, $R2> t);
+}
+
+class _RectangleDrawingCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, RectangleDrawing, $Out>
+    implements RectangleDrawingCopyWith<$R, RectangleDrawing, $Out> {
+  _RectangleDrawingCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<RectangleDrawing> $mapper =
+      RectangleDrawingMapper.ensureInitialized();
+  @override
+  $R call(
+          {int? left,
+          int? top,
+          int? width,
+          int? height,
+          Object? colorHex = $none}) =>
+      $apply(FieldCopyWithData({
+        if (left != null) #left: left,
+        if (top != null) #top: top,
+        if (width != null) #width: width,
+        if (height != null) #height: height,
+        if (colorHex != $none) #colorHex: colorHex
+      }));
+  @override
+  RectangleDrawing $make(CopyWithData data) => RectangleDrawing(
+      left: data.get(#left, or: $value.left),
+      top: data.get(#top, or: $value.top),
+      width: data.get(#width, or: $value.width),
+      height: data.get(#height, or: $value.height),
+      colorHex: data.get(#colorHex, or: $value.colorHex));
+
+  @override
+  RectangleDrawingCopyWith<$R2, RectangleDrawing, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _RectangleDrawingCopyWithImpl($value, $cast, t);
+}
+
+class SpinnerDrawingMapper extends SubClassMapperBase<SpinnerDrawing> {
+  SpinnerDrawingMapper._();
+
+  static SpinnerDrawingMapper? _instance;
+  static SpinnerDrawingMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = SpinnerDrawingMapper._());
+      GYWDrawingMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'SpinnerDrawing';
+
+  static int _$left(SpinnerDrawing v) => v.left;
+  static const Field<SpinnerDrawing, int> _f$left =
+      Field('left', _$left, opt: true, def: 0);
+  static int _$top(SpinnerDrawing v) => v.top;
+  static const Field<SpinnerDrawing, int> _f$top =
+      Field('top', _$top, opt: true, def: 0);
+  static double _$scale(SpinnerDrawing v) => v.scale;
+  static const Field<SpinnerDrawing, double> _f$scale =
+      Field('scale', _$scale, opt: true, def: 1.0);
+  static int? _$colorHex(SpinnerDrawing v) => v.colorHex;
+  static const Field<SpinnerDrawing, int> _f$colorHex =
+      Field('colorHex', _$colorHex, opt: true);
+  static AnimationTimingFunction _$animationTimingFunction(SpinnerDrawing v) =>
+      v.animationTimingFunction;
+  static const Field<SpinnerDrawing, AnimationTimingFunction>
+      _f$animationTimingFunction = Field(
+          'animationTimingFunction', _$animationTimingFunction,
+          opt: true, def: AnimationTimingFunction.linear);
+  static double _$spinsPerSecond(SpinnerDrawing v) => v.spinsPerSecond;
+  static const Field<SpinnerDrawing, double> _f$spinsPerSecond =
+      Field('spinsPerSecond', _$spinsPerSecond, opt: true, def: 1.0);
+
+  @override
+  final MappableFields<SpinnerDrawing> fields = const {
+    #left: _f$left,
+    #top: _f$top,
+    #scale: _f$scale,
+    #colorHex: _f$colorHex,
+    #animationTimingFunction: _f$animationTimingFunction,
+    #spinsPerSecond: _f$spinsPerSecond,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = 'SpinnerDrawing';
+  @override
+  late final ClassMapperBase superMapper = GYWDrawingMapper.ensureInitialized();
+
+  static SpinnerDrawing _instantiate(DecodingData data) {
+    return SpinnerDrawing(
+        left: data.dec(_f$left),
+        top: data.dec(_f$top),
+        scale: data.dec(_f$scale),
+        colorHex: data.dec(_f$colorHex),
+        animationTimingFunction: data.dec(_f$animationTimingFunction),
+        spinsPerSecond: data.dec(_f$spinsPerSecond));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static SpinnerDrawing fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<SpinnerDrawing>(map);
+  }
+
+  static SpinnerDrawing fromJson(String json) {
+    return ensureInitialized().decodeJson<SpinnerDrawing>(json);
+  }
+}
+
+mixin SpinnerDrawingMappable {
+  String toJson() {
+    return SpinnerDrawingMapper.ensureInitialized()
+        .encodeJson<SpinnerDrawing>(this as SpinnerDrawing);
+  }
+
+  Map<String, dynamic> toMap() {
+    return SpinnerDrawingMapper.ensureInitialized()
+        .encodeMap<SpinnerDrawing>(this as SpinnerDrawing);
+  }
+
+  SpinnerDrawingCopyWith<SpinnerDrawing, SpinnerDrawing, SpinnerDrawing>
+      get copyWith => _SpinnerDrawingCopyWithImpl(
+          this as SpinnerDrawing, $identity, $identity);
+  @override
+  String toString() {
+    return SpinnerDrawingMapper.ensureInitialized()
+        .stringifyValue(this as SpinnerDrawing);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return SpinnerDrawingMapper.ensureInitialized()
+        .equalsValue(this as SpinnerDrawing, other);
+  }
+
+  @override
+  int get hashCode {
+    return SpinnerDrawingMapper.ensureInitialized()
+        .hashValue(this as SpinnerDrawing);
+  }
+}
+
+extension SpinnerDrawingValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, SpinnerDrawing, $Out> {
+  SpinnerDrawingCopyWith<$R, SpinnerDrawing, $Out> get $asSpinnerDrawing =>
+      $base.as((v, t, t2) => _SpinnerDrawingCopyWithImpl(v, t, t2));
+}
+
+abstract class SpinnerDrawingCopyWith<$R, $In extends SpinnerDrawing, $Out>
+    implements GYWDrawingCopyWith<$R, $In, $Out> {
+  @override
+  $R call(
+      {int? left,
+      int? top,
+      double? scale,
+      int? colorHex,
+      AnimationTimingFunction? animationTimingFunction,
+      double? spinsPerSecond});
+  SpinnerDrawingCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+      Then<$Out2, $R2> t);
+}
+
+class _SpinnerDrawingCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, SpinnerDrawing, $Out>
+    implements SpinnerDrawingCopyWith<$R, SpinnerDrawing, $Out> {
+  _SpinnerDrawingCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<SpinnerDrawing> $mapper =
+      SpinnerDrawingMapper.ensureInitialized();
+  @override
+  $R call(
+          {int? left,
+          int? top,
+          double? scale,
+          Object? colorHex = $none,
+          AnimationTimingFunction? animationTimingFunction,
+          double? spinsPerSecond}) =>
+      $apply(FieldCopyWithData({
+        if (left != null) #left: left,
+        if (top != null) #top: top,
+        if (scale != null) #scale: scale,
+        if (colorHex != $none) #colorHex: colorHex,
+        if (animationTimingFunction != null)
+          #animationTimingFunction: animationTimingFunction,
+        if (spinsPerSecond != null) #spinsPerSecond: spinsPerSecond
+      }));
+  @override
+  SpinnerDrawing $make(CopyWithData data) => SpinnerDrawing(
+      left: data.get(#left, or: $value.left),
+      top: data.get(#top, or: $value.top),
+      scale: data.get(#scale, or: $value.scale),
+      colorHex: data.get(#colorHex, or: $value.colorHex),
+      animationTimingFunction: data.get(#animationTimingFunction,
+          or: $value.animationTimingFunction),
+      spinsPerSecond: data.get(#spinsPerSecond, or: $value.spinsPerSecond));
+
+  @override
+  SpinnerDrawingCopyWith<$R2, SpinnerDrawing, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _SpinnerDrawingCopyWithImpl($value, $cast, t);
+}

--- a/lib/src/drawings.mapper.dart
+++ b/lib/src/drawings.mapper.dart
@@ -144,9 +144,8 @@ class TextDrawingMapper extends SubClassMapperBase<TextDrawing> {
   static const Field<TextDrawing, int> _f$size =
       Field('size', _$size, opt: true, def: 24);
   static int _$colorHex(TextDrawing v) => v.colorHex;
-  static const Field<TextDrawing, int> _f$colorHex = Field(
-      'colorHex', _$colorHex,
-      key: 'color_hex', opt: true, def: 0xFF000000);
+  static const Field<TextDrawing, int> _f$colorHex =
+      Field('colorHex', _$colorHex, key: 'color', opt: true, def: 0xFF000000);
   static int? _$maxWidth(TextDrawing v) => v.maxWidth;
   static const Field<TextDrawing, int> _f$maxWidth =
       Field('maxWidth', _$maxWidth, key: 'max_width', opt: true);
@@ -324,9 +323,8 @@ class IconDrawingMapper extends SubClassMapperBase<IconDrawing> {
   static const Field<IconDrawing, int> _f$left =
       Field('left', _$left, opt: true, def: 0);
   static int _$colorHex(IconDrawing v) => v.colorHex;
-  static const Field<IconDrawing, int> _f$colorHex = Field(
-      'colorHex', _$colorHex,
-      key: 'color_hex', opt: true, def: 0xFF000000);
+  static const Field<IconDrawing, int> _f$colorHex =
+      Field('colorHex', _$colorHex, key: 'color', opt: true, def: 0xFF000000);
   static double _$scale(IconDrawing v) => v.scale;
   static const Field<IconDrawing, double> _f$scale =
       Field('scale', _$scale, opt: true, def: 1.0);
@@ -470,7 +468,7 @@ class RectangleDrawingMapper extends SubClassMapperBase<RectangleDrawing> {
       Field('height', _$height);
   static int? _$colorHex(RectangleDrawing v) => v.colorHex;
   static const Field<RectangleDrawing, int> _f$colorHex =
-      Field('colorHex', _$colorHex, key: 'color_hex', opt: true);
+      Field('colorHex', _$colorHex, key: 'color', opt: true);
 
   @override
   final MappableFields<RectangleDrawing> fields = const {
@@ -620,7 +618,7 @@ class SpinnerDrawingMapper extends SubClassMapperBase<SpinnerDrawing> {
       Field('scale', _$scale, opt: true, def: 1.0);
   static int? _$colorHex(SpinnerDrawing v) => v.colorHex;
   static const Field<SpinnerDrawing, int> _f$colorHex =
-      Field('colorHex', _$colorHex, key: 'color_hex', opt: true);
+      Field('colorHex', _$colorHex, key: 'color', opt: true);
   static AnimationTimingFunction _$animationTimingFunction(SpinnerDrawing v) =>
       v.animationTimingFunction;
   static const Field<SpinnerDrawing, AnimationTimingFunction>

--- a/lib/src/drawings.mapper.dart
+++ b/lib/src/drawings.mapper.dart
@@ -144,14 +144,15 @@ class TextDrawingMapper extends SubClassMapperBase<TextDrawing> {
   static const Field<TextDrawing, int> _f$size =
       Field('size', _$size, opt: true, def: 24);
   static int _$colorHex(TextDrawing v) => v.colorHex;
-  static const Field<TextDrawing, int> _f$colorHex =
-      Field('colorHex', _$colorHex, opt: true, def: 0xFF000000);
+  static const Field<TextDrawing, int> _f$colorHex = Field(
+      'colorHex', _$colorHex,
+      key: 'color_hex', opt: true, def: 0xFF000000);
   static int? _$maxWidth(TextDrawing v) => v.maxWidth;
   static const Field<TextDrawing, int> _f$maxWidth =
-      Field('maxWidth', _$maxWidth, opt: true);
+      Field('maxWidth', _$maxWidth, key: 'max_width', opt: true);
   static int? _$maxLines(TextDrawing v) => v.maxLines;
   static const Field<TextDrawing, int> _f$maxLines =
-      Field('maxLines', _$maxLines, opt: true, def: 1);
+      Field('maxLines', _$maxLines, key: 'max_lines', opt: true, def: 1);
   static int _$left(TextDrawing v) => v.left;
   static const Field<TextDrawing, int> _f$left =
       Field('left', _$left, opt: true, def: 0);
@@ -323,8 +324,9 @@ class IconDrawingMapper extends SubClassMapperBase<IconDrawing> {
   static const Field<IconDrawing, int> _f$left =
       Field('left', _$left, opt: true, def: 0);
   static int _$colorHex(IconDrawing v) => v.colorHex;
-  static const Field<IconDrawing, int> _f$colorHex =
-      Field('colorHex', _$colorHex, opt: true, def: 0xFF000000);
+  static const Field<IconDrawing, int> _f$colorHex = Field(
+      'colorHex', _$colorHex,
+      key: 'color_hex', opt: true, def: 0xFF000000);
   static double _$scale(IconDrawing v) => v.scale;
   static const Field<IconDrawing, double> _f$scale =
       Field('scale', _$scale, opt: true, def: 1.0);
@@ -468,7 +470,7 @@ class RectangleDrawingMapper extends SubClassMapperBase<RectangleDrawing> {
       Field('height', _$height);
   static int? _$colorHex(RectangleDrawing v) => v.colorHex;
   static const Field<RectangleDrawing, int> _f$colorHex =
-      Field('colorHex', _$colorHex, opt: true);
+      Field('colorHex', _$colorHex, key: 'color_hex', opt: true);
 
   @override
   final MappableFields<RectangleDrawing> fields = const {
@@ -618,16 +620,19 @@ class SpinnerDrawingMapper extends SubClassMapperBase<SpinnerDrawing> {
       Field('scale', _$scale, opt: true, def: 1.0);
   static int? _$colorHex(SpinnerDrawing v) => v.colorHex;
   static const Field<SpinnerDrawing, int> _f$colorHex =
-      Field('colorHex', _$colorHex, opt: true);
+      Field('colorHex', _$colorHex, key: 'color_hex', opt: true);
   static AnimationTimingFunction _$animationTimingFunction(SpinnerDrawing v) =>
       v.animationTimingFunction;
   static const Field<SpinnerDrawing, AnimationTimingFunction>
       _f$animationTimingFunction = Field(
           'animationTimingFunction', _$animationTimingFunction,
-          opt: true, def: AnimationTimingFunction.linear);
+          key: 'animation_timing_function',
+          opt: true,
+          def: AnimationTimingFunction.linear);
   static double _$spinsPerSecond(SpinnerDrawing v) => v.spinsPerSecond;
-  static const Field<SpinnerDrawing, double> _f$spinsPerSecond =
-      Field('spinsPerSecond', _$spinsPerSecond, opt: true, def: 1.0);
+  static const Field<SpinnerDrawing, double> _f$spinsPerSecond = Field(
+      'spinsPerSecond', _$spinsPerSecond,
+      key: 'spins_per_second', opt: true, def: 1.0);
 
   @override
   final MappableFields<SpinnerDrawing> fields = const {

--- a/lib/src/fonts.dart
+++ b/lib/src/fonts.dart
@@ -43,16 +43,14 @@ class GYWFont {
   }
 
   @override
-  bool operator ==(Object other) {
-    if (other is GYWFont) {
-      return filename == other.filename;
-    } else {
-      return false;
-    }
-  }
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GYWFont &&
+          runtimeType == other.runtimeType &&
+          filename == other.filename;
 
   @override
-  int get hashCode => Object.hash(name, filename);
+  int get hashCode => filename.hashCode;
 }
 
 /// Roboto Mono Normal

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -45,22 +45,10 @@ class GYWIcon {
       identical(this, other) ||
       other is GYWIcon &&
           runtimeType == other.runtimeType &&
-          name == other.name &&
-          filename == other.filename &&
-          width == other.width &&
-          height == other.height &&
-          pathPng == other.pathPng &&
-          pathSvg == other.pathSvg;
+          filename == other.filename;
 
   @override
-  int get hashCode => Object.hash(
-        name,
-        filename,
-        width,
-        height,
-        pathPng,
-        pathSvg,
-      );
+  int get hashCode => filename.hashCode;
 }
 
 /// The [GYWIcon] icons supported by default on aRdent smart glasses.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,12 +9,16 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
+  dart_mappable: ^4.2.2
   flutter:
     sdk: flutter
   flutter_blue_plus: ^1.31.4
 
 dev_dependencies:
-  dartdoc: ^6.3.0
+  analyzer: ^6.4.1
+  build_runner: ^2.4.9
+  dart_mappable_builder: ^4.2.3
+  dartdoc: ^8.0.8
   flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(iconMapper.decode(iconMapper.encode(icon)), icon);
     });
 
-    test("Text without optional values", () {
+    test("TextDrawing without optional values", () {
       final GYWDrawing drawing = TextDrawing(
         text: "Text",
         font: GYWFonts.robotoMono.font,
@@ -44,7 +44,7 @@ void main() {
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
-    test("Text with optional values", () {
+    test("TextDrawing with optional values", () {
       final GYWDrawing drawing = TextDrawing(
         left: 100,
         top: 200,
@@ -59,7 +59,7 @@ void main() {
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
-    test("Icon", () {
+    test("IconDrawing", () {
       final GYWIcon icon = GYWIcons.checkbox.icon;
 
       final GYWDrawing drawing = IconDrawing(icon);
@@ -67,7 +67,7 @@ void main() {
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
-    test("Icon with position", () {
+    test("IconDrawing with position", () {
       final GYWIcon icon = GYWIcons.up.icon;
 
       final GYWDrawing drawing = IconDrawing(
@@ -79,7 +79,7 @@ void main() {
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
-    test("Icon with color", () {
+    test("IconDrawing with color", () {
       final GYWIcon icon = GYWIcons.left.icon;
 
       final GYWDrawing drawing = IconDrawing(

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -1,5 +1,6 @@
 import "dart:io";
 
+import "package:dart_mappable/dart_mappable.dart";
 import "package:flutter/material.dart";
 import "package:flutter_gyw/flutter_gyw.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -22,7 +23,7 @@ void main() {
         text: "Text with position",
         font: GYWFonts.robotoMonoBold.font,
         size: 48,
-        color: const Color(0x12345678),
+        colorHex: 0x12345678,
         maxWidth: 300,
         maxLines: 3,
       );
@@ -57,7 +58,7 @@ void main() {
         icon,
         left: 120,
         top: 220,
-        color: Colors.green,
+        colorHex: Colors.green.value,
       );
 
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
@@ -69,7 +70,7 @@ void main() {
         "data": "Test",
       };
 
-      expect(() => GYWDrawing.fromJson(json), throwsA(isA<UnsupportedError>()));
+      expect(() => GYWDrawing.fromMap(json), throwsA(isA<MapperException>()));
     });
   });
 

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -3,38 +3,10 @@ import "dart:io";
 import "package:dart_mappable/dart_mappable.dart";
 import "package:flutter/material.dart";
 import "package:flutter_gyw/flutter_gyw.dart";
-import "package:flutter_gyw/src/custom_mappers.dart";
 import "package:flutter_test/flutter_test.dart";
-
-const fontMapper = GYWFontMapper();
-const iconMapper = GYWIconMapper();
 
 void main() {
   group("JSON", () {
-    test("Built-in font", () {
-      final GYWFont font = GYWFonts.robotoMonoBold.font;
-      expect(fontMapper.decode(fontMapper.encode(font)), font);
-    });
-
-    test("Custom font", () {
-      const GYWFont font = GYWFont(filename: "custo");
-      // Unknown fonts are replaced by the default one.
-      expect(
-        fontMapper.decode(fontMapper.encode(font)),
-        GYWFonts.robotoMono.font,
-      );
-    });
-
-    test("Built-in icon", () {
-      final GYWIcon icon = GYWIcons.nfc.icon;
-      expect(iconMapper.decode(iconMapper.encode(icon)), icon);
-    });
-
-    test("Custom icon", () {
-      const GYWIcon icon = GYWIcon(name: "custom", filename: "custom");
-      expect(iconMapper.decode(iconMapper.encode(icon)), icon);
-    });
-
     test("TextDrawing without optional values", () {
       final GYWDrawing drawing = TextDrawing(
         text: "Text",

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -3,10 +3,38 @@ import "dart:io";
 import "package:dart_mappable/dart_mappable.dart";
 import "package:flutter/material.dart";
 import "package:flutter_gyw/flutter_gyw.dart";
+import "package:flutter_gyw/src/custom_mappers.dart";
 import "package:flutter_test/flutter_test.dart";
+
+const fontMapper = GYWFontMapper();
+const iconMapper = GYWIconMapper();
 
 void main() {
   group("JSON", () {
+    test("Built-in font", () {
+      final GYWFont font = GYWFonts.robotoMonoBold.font;
+      expect(fontMapper.decode(fontMapper.encode(font)), font);
+    });
+
+    test("Custom font", () {
+      const GYWFont font = GYWFont(filename: "custo");
+      // Unknown fonts are replaced by the default one.
+      expect(
+        fontMapper.decode(fontMapper.encode(font)),
+        GYWFonts.robotoMono.font,
+      );
+    });
+
+    test("Built-in icon", () {
+      final GYWIcon icon = GYWIcons.nfc.icon;
+      expect(iconMapper.decode(iconMapper.encode(icon)), icon);
+    });
+
+    test("Custom icon", () {
+      const GYWIcon icon = GYWIcon(name: "custom", filename: "custom");
+      expect(iconMapper.decode(iconMapper.encode(icon)), icon);
+    });
+
     test("Text without optional values", () {
       final GYWDrawing drawing = TextDrawing(
         text: "Text",

--- a/test/drawing_test.dart
+++ b/test/drawing_test.dart
@@ -92,6 +92,31 @@ void main() {
       expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
     });
 
+    test("RectangleDrawing", () {
+      final GYWDrawing drawing = RectangleDrawing(
+        left: 100,
+        top: 200,
+        width: 300,
+        height: 400,
+        colorHex: Colors.red.value,
+      );
+
+      expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
+    });
+
+    test("SpinnerDrawing", () {
+      final GYWDrawing drawing = SpinnerDrawing(
+        left: 100,
+        top: 200,
+        scale: 1.23,
+        colorHex: Colors.blue.value,
+        animationTimingFunction: AnimationTimingFunction.ease_out,
+        spinsPerSecond: 2.5,
+      );
+
+      expect(GYWDrawing.fromJson(drawing.toJson()), drawing);
+    });
+
     test("Unsupported type", () {
       final json = {
         "type": "unsupported",


### PR DESCRIPTION
- The [dart_mappable](https://pub.dev/packages/dart_mappable) library has been integrated for the following benefits:
  - Generate the serialization and deserialization code which replaces our own `fromJson`/`toJson` methods.
  - Automatic generation of `toString`, `hashCode`, `operator ==`, and `copyWith`.

- `GYWDrawing` is now a sealed class, which allows pattern matching to be exhaustive.