### PR TITLE
Write to Bluetooth characteristics without waiting for a response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [REFACTOR] Simplify the use of user-defined icons
 * [REFACTOR] Remove font prefixes
 * [REFACTOR] Replace manual serialization code with dart_mappable
+* [IMP] Write to bluetooth characteristics without waiting for a response
 
 ## 1.2.1
 * [ADD] Add spinner image

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -263,7 +263,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
         chunk = data.sublist(start);
       }
 
-      await characteristic.write(chunk);
+      await characteristic.write(chunk, withoutResponse: true);
 
       start += 20;
       end += 20;


### PR DESCRIPTION
Recent Bluetooth optimizations made to the firmware have added support for writing without response, which enables faster and more flexible device interactions. The API will now always prefer this type of write in all Bluetooth communications.