### PR TITLE
Remove the `startDisplay` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* [DEL] Remove the `startDisplay` method
+
 ## 2.0.0
 * [DEL] Remove deprecated functionality
 * [REFACTOR] Encode positions as int16 instead of int32

--- a/README.md
+++ b/README.md
@@ -67,15 +67,7 @@ Then, pick the `GYWBtDevice`  ([documentation](flutter_gyw/GYWBtDevice-class.htm
 await device.connect();
 ```
 
-### Step 3 : Turn the screen on
-
-Notify the device so that it turns it screen on.
-
-```dart
-await device.startDisplay()
-```
-
-### Step 4 : Make a drawing
+### Step 3 : Make a drawing
 
 Create a list of drawings that you want to send to the device.
 
@@ -89,7 +81,7 @@ final List<GYWDrawing> drawings = [
 ];
 ```
 
-### Step 5 : Send the drawings
+### Step 4 : Send the drawings
 
 Send the drawings to the connected device.
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -76,7 +76,6 @@ class _GYWExampleScreenState extends State<GYWExampleScreen> {
                   subtitle: Text(device.id),
                   onTap: () async {
                     if (await device.connect()) {
-                      await device.startDisplay();
                       setState(() => connectedDevice = device);
                     }
                   },

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -270,25 +270,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Turns the screen on and initializes it for future drawings.
-  ///
-  /// This method must be called once before performing display operations.
-  Future<void> startDisplay() async {
-    if (_screenOn) {
-      // Skip the command
-      return;
-    }
-
-    final command = GYWBtCommand(
-      GYWCharacteristic.ctrlDisplay,
-      int8Bytes(GYWControlCode.startDisplay.value),
-    );
-
-    await _sendBTCommand(command);
-
-    _screenOn = true;
-  }
-
   /// Turns the display backlight on or off
   Future<void> enableBacklight(
     bool enable,

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -20,7 +20,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   bool _isConnecting = false;
   bool _isDisconnecting = false;
   bool _isConnected = false;
-  bool _screenOn = false;
 
   /// Whether the connection to the device is in progress
   bool get isConnecting => _isConnecting;
@@ -144,7 +143,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
       _isDisconnecting = false;
     }
 
-    _screenOn = false;
     notifyListeners();
 
     return !isConnected;

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -16,9 +16,6 @@ enum GYWCharacteristic {
 
 /// A code to operate aRdent smart glasses
 enum GYWControlCode {
-  /// Switch on the screen
-  startDisplay(0x01),
-
   /// Show an image on the screen
   displayImage(0x02),
 


### PR DESCRIPTION
The screen gets powered on automatically, so `startDisplay` is no longer necessary.