### PR TITLE
Remove some technical features that are not needed in the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+* [DEL] Remove some technical features that are not needed in the library
+
 ## 2.0.1
 * [DEL] Remove the `startDisplay` method
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ for (GYWDrawing drawing in drawings) {
 
 ## Example
 
-A complete example can be found [here](example/example.dart)
+A complete example can be found [here](https://github.com/getyourway/flutter_gyw/blob/master/example/example.dart)
 
 ## Drawings
 

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -182,57 +182,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     }
   }
 
-  /// Sets the screen brightness.
-  ///
-  /// The value must be between 0 and 1.
-  Future<void> setBrightness(double value) async {
-    assert(value >= 0 && value <= 1, "Brightness must be between 0 and 1");
-
-    final controlBytes = BytesBuilder()
-      ..addByte(GYWControlCode.setBrightness.value)
-      ..add(int8Bytes((value * 255).toInt()));
-
-    final command = GYWBtCommand(
-      GYWCharacteristic.ctrlDisplay,
-      controlBytes.toBytes(),
-    );
-
-    await _sendBTCommand(command);
-  }
-
-  /// Sets the screen contrast.
-  ///
-  /// The value must be between 0 and 1.
-  Future<void> setContrast(double value) async {
-    assert(value >= 0 && value <= 1, "Contrast must be between 0 and 1");
-
-    final controlBytes = BytesBuilder()
-      ..addByte(GYWControlCode.setContrast.value)
-      ..add(int8Bytes((value * 255).toInt()));
-
-    final command = GYWBtCommand(
-      GYWCharacteristic.ctrlDisplay,
-      controlBytes.toBytes(),
-    );
-
-    await _sendBTCommand(command);
-  }
-
-  /// Enables or disables the screen autorotation.
-  Future<void> autoRotateScreen(
-    bool enable,
-  ) async {
-    final controlBytes = BytesBuilder()
-      ..addByte(GYWControlCode.autoRotateScreen.value)
-      ..addByte(enable ? 1 : 0);
-
-    final command = GYWBtCommand(
-      GYWCharacteristic.ctrlDisplay,
-      controlBytes.toBytes(),
-    );
-    await _sendBTCommand(command);
-  }
-
   Future<void> _sendBTCommand(GYWBtCommand command) async {
     final fb.BluetoothCharacteristic? characteristic =
         await _findCharacteristic(command.characteristic.uuid);
@@ -266,21 +215,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
       start += 20;
       end += 20;
     }
-  }
-
-  /// Turns the display backlight on or off
-  Future<void> enableBacklight(
-    bool enable,
-  ) async {
-    final controlBytes = BytesBuilder()
-      ..addByte(GYWControlCode.enableBacklight.value)
-      ..addByte(enable ? 1 : 0);
-
-    final command = GYWBtCommand(
-      GYWCharacteristic.ctrlDisplay,
-      controlBytes.toBytes(),
-    );
-    await _sendBTCommand(command);
   }
 
   /// Reset the content of the screen and its background color.

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -25,21 +25,6 @@ enum GYWControlCode {
   /// Clear the screen
   clear(0x05),
 
-  /// Change the contrast
-  setContrast(0x06),
-
-  /// Change the brightness
-  setBrightness(0x07),
-
-  /// Change the text font of the next text elements
-  setFont(0x08),
-
-  /// Enable or disable screen auto-rotate
-  autoRotateScreen(0x0A),
-
-  /// Enable or disable the display backlight
-  enableBacklight(0x0B),
-
   /// Draw a colored rectangle
   drawRectangle(0x0C),
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_gyw
-version: 2.0.1
+version: 2.0.2
 description: A package to manage interactions with aRdent smart glasses.
 repository: https://github.com/getyourway/flutter_gyw/
 
@@ -12,14 +12,14 @@ dependencies:
   dart_mappable: ^4.2.2
   flutter:
     sdk: flutter
-  flutter_blue_plus: ^1.31.4
+  flutter_blue_plus: ^1.32.11
 
 dev_dependencies:
-  analyzer: ^6.4.1
-  build_runner: ^2.4.9
+  analyzer: ^6.7.0
+  build_runner: ^2.4.12
   dart_mappable_builder: ^4.2.3
-  dartdoc: ^8.0.8
-  flutter_lints: ^3.0.1
+  dartdoc: ^8.0.13
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Some features are seen as advanced and quite technical. They are usually not needed to use the glasses. In order to keep a simple and easily maintainable library, these have been removed from the library.

Those methods include:
* `setBrightness`, `setContrast`
* `enableBacklight`, `autoRotateScreen`

The version has also been bumped to 2.0.2 and the package dependencies have been upgraded.