### PR TITLE
Fix the use of images that are not library icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3
+* [FIX] Fix the use of images that are not library icons
+
 ## 2.0.2
 * [DEL] Remove some technical features that are not needed in the library
 

--- a/lib/src/bt_manager.dart
+++ b/lib/src/bt_manager.dart
@@ -13,6 +13,7 @@ class GYWBtManager {
   }
 
   Future<void> _init() async {
+    FlutterBluePlus.setLogLevel(LogLevel.info);
     FlutterBluePlus.adapterState.listen((state) {
       if (bluetoothOn != (state == BluetoothAdapterState.on)) {
         bluetoothOn = state == BluetoothAdapterState.on;

--- a/lib/src/drawings.dart
+++ b/lib/src/drawings.dart
@@ -1,4 +1,3 @@
-import "dart:convert";
 import "dart:typed_data";
 
 import "package:dart_mappable/dart_mappable.dart";
@@ -160,7 +159,7 @@ class TextDrawing extends GYWDrawing with TextDrawingMappable {
     controlBytes.add(int16Bytes(left));
     controlBytes.add(int16Bytes(top));
 
-    controlBytes.add(utf8.encode(font.filename));
+    controlBytes.add(textBytes(font.filename));
     controlBytes.add(int8Bytes(size));
 
     controlBytes.add(rgba8888BytesFromColor(color));
@@ -168,7 +167,7 @@ class TextDrawing extends GYWDrawing with TextDrawingMappable {
     return [
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
-        const Utf8Encoder().convert(line),
+        textBytes(line),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
@@ -223,7 +222,7 @@ class IconDrawing extends GYWDrawing with IconDrawingMappable {
     return <GYWBtCommand>[
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
-        const Utf8Encoder().convert("${icon.filename}.svg"),
+        textBytes("${icon.filename}${icon.library ? '.svg' : ''}"),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,
@@ -332,7 +331,7 @@ class SpinnerDrawing extends GYWDrawing with SpinnerDrawingMappable {
     return [
       GYWBtCommand(
         GYWCharacteristic.nameDisplay,
-        const Utf8Encoder().convert("spinner_1.svg"),
+        textBytes("spinner_1.svg"),
       ),
       GYWBtCommand(
         GYWCharacteristic.ctrlDisplay,

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -1,5 +1,9 @@
+import "dart:convert";
 import "dart:typed_data";
 import "dart:ui";
+
+/// Converts a String into UTF-8 bytes
+Uint8List textBytes(String value) => utf8.encode(value);
 
 /// Converts an int16 into bytes
 Uint8List int16Bytes(

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -15,7 +15,7 @@ class GYWIcon {
   /// The height (in pixels) of the icon
   final double height;
 
-  /// Whether the icon is available by default on aRdent
+  /// Whether the icon is available by default on aRdent or not
   final bool library;
 
   /// The path of the associated PNG file in the assets folder

--- a/lib/src/icons.dart
+++ b/lib/src/icons.dart
@@ -15,11 +15,38 @@ class GYWIcon {
   /// The height (in pixels) of the icon
   final double height;
 
+  /// Whether the icon is available by default on aRdent
+  final bool library;
+
   /// The path of the associated PNG file in the assets folder
-  final String pathPng;
+  String get pathPng {
+    if (library) {
+      if (filename.endsWith(".svg")) {
+        return "assets/icons/${filename.replaceAll(".svg", ".png")}";
+      } else if (filename.endsWith(".png")) {
+        return "assets/icons/$filename";
+      } else {
+        return "assets/icons/$filename.png";
+      }
+    } else {
+      return "assets/icons/unknown.png";
+    }
+  }
 
   /// The path of the associated SVG file in the assets folder
-  final String pathSvg;
+  String get pathSvg {
+    if (library) {
+      if (filename.endsWith(".svg")) {
+        return "assets/icons/$filename";
+      } else if (filename.endsWith(".png")) {
+        return "assets/icons/${filename.replaceAll(".png", ".svg")}";
+      } else {
+        return "assets/icons/$filename.svg";
+      }
+    } else {
+      return "assets/icons/unknown.svg";
+    }
+  }
 
   /// Creates an icon.
   const GYWIcon({
@@ -27,9 +54,7 @@ class GYWIcon {
     required this.filename,
     this.width = 48,
     this.height = 48,
-    this.pathPng = "assets/icons/unknown.png",
-    this.pathSvg = "assets/icons/unknown.svg",
-  });
+  }) : library = false;
 
   const GYWIcon._library({
     required this.name,
@@ -37,8 +62,7 @@ class GYWIcon {
     this.width = 48,
     // ignore: unused_element
     this.height = 48,
-  })  : pathPng = "assets/icons/$filename.png",
-        pathSvg = "assets/icons/$filename.svg";
+  }) : library = true;
 
   @override
   bool operator ==(Object other) =>


### PR DESCRIPTION
* `.svg` was added to any `GYWIcon` filename, which prevent the use of the object for custom icons, i.e. images that are sent to a single device with the `sendFile` operation. This is now fixed by turning `pathPng` and `pathSvg` into getters.
* The UTF8 encoding operations have been standardized in a `textBytes` method
* The log level of Flutter Bluetooth library has been reduced to Info to reduce the number of log messages