### PR TITLE
Eagerly cache characteristics and expose the cache publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.3
 * [FIX] Fix the use of images that are not library icons
+* [IMP] Eagerly cache characteristics and expose the cache publicly
 
 ## 2.0.2
 * [DEL] Remove some technical features that are not needed in the library

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -142,6 +142,9 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
       _deviceStateListener = null;
     }
 
+    // Clear saved characteristics
+    _characteristics.clear();
+
     try {
       await fbDevice.disconnect();
       _isConnected = false;

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -45,8 +45,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
   StreamSubscription<fb.BluetoothConnectionState>? _deviceStateListener;
 
-  Map<String, fb.BluetoothCharacteristic?> _characteristics =
-      <String, fb.BluetoothCharacteristic?>{};
+  final Map<String, fb.BluetoothCharacteristic> _characteristics = {};
 
   /// Creates a bluetooth device.
   GYWBtDevice({
@@ -86,6 +85,16 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
 
     try {
       await fbDevice.connect(timeout: const Duration(seconds: 5));
+
+      // Discover all charactersitics
+      _characteristics.clear();
+      final services = await fbDevice.discoverServices();
+
+      for (final service in services) {
+        for (final characteristic in service.characteristics) {
+          _characteristics[characteristic.uuid.toString()] = characteristic;
+        }
+      }
     } on TimeoutException {
       _isConnected = false;
       _isConnecting = false;
@@ -133,9 +142,6 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
       _deviceStateListener = null;
     }
 
-    // Clear saved characteristics
-    _characteristics = <String, fb.BluetoothCharacteristic?>{};
-
     try {
       await fbDevice.disconnect();
       _isConnected = false;
@@ -148,29 +154,9 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
     return !isConnected;
   }
 
-  Future<fb.BluetoothCharacteristic?> _findCharacteristic(String uuid) async {
-    if (_characteristics[uuid] != null) {
-      return _characteristics[uuid];
-    }
-
-    final List<fb.BluetoothService?> services =
-        await fbDevice.discoverServices();
-
-    for (final fb.BluetoothService? service in services) {
-      try {
-        final c = service?.characteristics
-            .firstWhere((element) => element.uuid == fb.Guid(uuid));
-
-        // Save characteristic in cache
-        _characteristics[uuid] = c;
-
-        return c;
-      } on StateError {
-        continue;
-      }
-    }
-
-    return null;
+  /// Find a characteristic by its UUID
+  fb.BluetoothCharacteristic? findCharacteristic(String uuid) {
+    return _characteristics[uuid];
   }
 
   /// Sends data to the aRdent device to display a [GYWDrawing]
@@ -183,11 +169,12 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   }
 
   Future<void> _sendBTCommand(GYWBtCommand command) async {
-    final fb.BluetoothCharacteristic? characteristic =
-        await _findCharacteristic(command.characteristic.uuid);
+    final characteristic = findCharacteristic(command.characteristic.uuid);
 
     if (characteristic == null) {
-      throw const GYWException("Bluetooth characteristic not found");
+      throw GYWException(
+        "Bluetooth characteristic ${command.characteristic.uuid} not found",
+      );
     } else {
       await _sendData(characteristic, command.data);
     }


### PR DESCRIPTION
Expose the characteristic cache for use in `pygyw_dev` because `pygyw_dev` currently builds its own cache but it doesn't know when aRdent disconnects, so it remains stale after a re-connection.