### PR TITLE
Annotate some symbols with `@internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.0.3
+* [IMP] Annotate `GYWBtDevice.fbDevice` and `GYWBtDevice.findCharacteristic` with `@internal`
 * [FIX] Fix the use of images that are not library icons
 * [IMP] Eagerly cache characteristics and expose the cache publicly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 2.0.3
+## 2.0.4
 * [IMP] Annotate `GYWBtDevice.fbDevice` and `GYWBtDevice.findCharacteristic` with `@internal`
+
+## 2.0.3
 * [FIX] Fix the use of images that are not library icons
 * [IMP] Eagerly cache characteristics and expose the cache publicly
 

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -5,6 +5,7 @@ import "dart:typed_data";
 import "package:flutter/material.dart";
 import "package:flutter_blue_plus/flutter_blue_plus.dart" as fb;
 import "package:flutter_gyw/flutter_gyw.dart";
+import "package:meta/meta.dart";
 
 import "commands.dart";
 import "helpers.dart";
@@ -12,6 +13,7 @@ import "helpers.dart";
 /// The representation of a Bluetooth device in the library
 class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   /// The encapsulated FlutterBluePlus device
+  @internal
   fb.BluetoothDevice fbDevice;
 
   /// The time when the device was last detected
@@ -158,6 +160,7 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
   }
 
   /// Find a characteristic by its UUID
+  @internal
   fb.BluetoothCharacteristic? findCharacteristic(String uuid) {
     return _characteristics[uuid];
   }

--- a/lib/src/bt_manager.dart
+++ b/lib/src/bt_manager.dart
@@ -1,4 +1,5 @@
 import "package:flutter_blue_plus/flutter_blue_plus.dart";
+import "package:flutter_gyw/src/commands.dart";
 
 import "bt_device.dart";
 import "exceptions.dart";
@@ -71,7 +72,9 @@ class GYWBtManager {
       _isScanning = true;
 
       // Get devices that are already connected
-      final connectedDevices = await FlutterBluePlus.systemDevices;
+      final connectedDevices = await FlutterBluePlus.systemDevices([
+        Guid(GYWService.display.uuid),
+      ]);
 
       // Add them to the manager list
       for (final BluetoothDevice fbDevice in connectedDevices) {

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -5,6 +5,7 @@ enum GYWService {
   /// Service to control the display
   display("9f3443f3-5149-4d53-9b92-35def7b82e51");
 
+  /// The UUID of the service
   final String uuid;
 
   const GYWService(this.uuid);

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -1,5 +1,15 @@
 import "package:flutter/services.dart";
 
+/// A class gathering the services used on aRdent
+enum GYWService {
+  /// Service to control the display
+  display("9f3443f3-5149-4d53-9b92-35def7b82e51");
+
+  final String uuid;
+
+  const GYWService(this.uuid);
+}
+
 /// A class gathering the characteristics used on aRdent
 enum GYWCharacteristic {
   /// Characterisitic to control the display

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_blue_plus: ^1.32.11
+  meta: ^1.15.0
 
 dev_dependencies:
   analyzer: ^6.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_gyw
-version: 2.0.2
+version: 2.0.4
 description: A package to manage interactions with aRdent smart glasses.
 repository: https://github.com/getyourway/flutter_gyw/
 


### PR DESCRIPTION
Attempt to make some symbols package-private by triggering a lint warning if a user references these. This annotation does not enforce anything, but it makes it harder to reference symbols that should only be used by `flutter_gyw`.