### PR TITLE
Fix `GYWBtDevice.connect` returning true when connection fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.4
 * [IMP] Annotate `GYWBtDevice.fbDevice` and `GYWBtDevice.findCharacteristic` with `@internal`
+* [FIX] Fix `GYWBtDevice.connect` returning true when connection fails
 
 ## 2.0.3
 * [FIX] Fix the use of images that are not library icons

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -97,14 +97,14 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
           _characteristics[characteristic.uuid.toString()] = characteristic;
         }
       }
-    } on TimeoutException {
+    } on Exception catch (e, s) {
+      log("An error occured during BT Connection", error: e, stackTrace: s);
+
       _isConnected = false;
       _isConnecting = false;
       notifyListeners();
 
       return isConnected;
-    } on Exception catch (e, s) {
-      log("An error occured during BT Connection", error: e, stackTrace: s);
     }
 
     // Device is already connected


### PR DESCRIPTION
`GYWBtDevice.connect` could have returned true even though the connection fails.