### PR TITLE
Fix unhandled exception when aRdent is disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.4
 * [IMP] Annotate `GYWBtDevice.fbDevice` and `GYWBtDevice.findCharacteristic` with `@internal`
+* [FIX] Fix `GYWBtDevice.connect` returning true when connection fails
 
 ## 2.0.3
 * [FIX] Fix the use of images that are not library icons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.4
 * [IMP] Annotate `GYWBtDevice.fbDevice` and `GYWBtDevice.findCharacteristic` with `@internal`
 * [FIX] Fix `GYWBtDevice.connect` returning true when connection fails
+* [FIX] Fix `GYWStatusException: The device is already trying to be disconnected.`
 
 ## 2.0.3
 * [FIX] Fix the use of images that are not library icons

--- a/lib/src/bt_device.dart
+++ b/lib/src/bt_device.dart
@@ -97,14 +97,14 @@ class GYWBtDevice with ChangeNotifier implements Comparable<GYWBtDevice> {
           _characteristics[characteristic.uuid.toString()] = characteristic;
         }
       }
-    } on TimeoutException {
+    } on Exception catch (e, s) {
+      log("An error occured during BT Connection", error: e, stackTrace: s);
+
       _isConnected = false;
       _isConnecting = false;
       notifyListeners();
 
       return isConnected;
-    } on Exception catch (e, s) {
-      log("An error occured during BT Connection", error: e, stackTrace: s);
     }
 
     // Device is already connected


### PR DESCRIPTION
Fix the exception `GYWStatusException: The device is already trying to be disconnected.` by avoiding calling the `disconnect` method if aRdent is already disconnected.